### PR TITLE
docs: Add details on PAT lifecycle

### DIFF
--- a/docs/console/api.md
+++ b/docs/console/api.md
@@ -48,6 +48,15 @@ Vous voyez ensuite le nouveau jeton créé et sa future date d'expiration.
 
 <img src={ShivaProfil005} />
 
+:::info Cycle de vie du token d'authentification
+Lorsque vous utilisez votre **Personal Access Token (PAT)** pour vous authentifier auprès de l'API, vous recevez en retour un token d'accès. Il est important de noter que ce token d'accès est un **JSON Web Token (JWT)** avec une durée de vie limitée.
+
+-   **Durée de vie** : Chaque token JWT est valide pour une durée de **5 minutes**.
+-   **Vérification** : Vous pouvez vérifier la date d'émission (`iat`) et la date d'expiration (`exp`) de votre token en le décodant. Des outils en ligne comme [jwt.io](https://jwt.io) vous permettent de le faire facilement.
+
+Une fois le token expiré, vous devrez vous ré-authentifier avec votre PAT pour en obtenir un nouveau. Il est donc recommandé de gérer ce cycle de vie dans vos scripts et applications en prévoyant un renouvellement automatique du token.
+:::
+
 ## Accès au portail API
 
 La documentation OpenAPI 3.0 (Swagger) des APIs de la console Cloud Temple est disponible directement dans l'application :

--- a/i18n/de/docusaurus-plugin-content-docs/current/console/api.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/console/api.md
@@ -13,8 +13,8 @@ import ShivaApi004 from './images/shiva_api_004.png'
 
 ## API-Schlüssel
 
-Der __API-Schlüssel__ dient zur Authentifizierung, wenn Sie Anfragen an die API stellen möchten. Die Erstellung eines API-Schlüssels, auch bekannt als __Personal Access Token (PAT)__,
-ist eine sichere Methode, um sich an die Shiva-APIs anzumelden, ohne eine grafische Benutzeroberfläche nutzen zu müssen. Jeder dieser Tokens ist mit einem Mandanten und dem Benutzer verknüpft, der ihn erstellt hat.
+Der __API-Schlüssel__ ermöglicht die Authentifizierung, wenn Sie Anfragen an die API stellen möchten. Die Erstellung eines API-Schlüssels, auch bekannt als __Personal Access Token (PAT)__,
+ist eine sichere Methode, um sich an die Shiva-APIs anzumelden, ohne eine grafische Benutzeroberfläche verwenden zu müssen. Jeder dieser Tokens ist mit einem Tenant und dem Benutzer verknüpft, der ihn erstellt hat.
 
 Die Erstellung dieses Tokens erfolgt über Ihr Konto. Es ist möglich, mehrere Schlüssel zu generieren und für jeden die Berechtigungen entsprechend Ihren Rechten einzurichten.
 
@@ -26,15 +26,15 @@ Im Profilmenü klicken Sie auf __'Persönlichen Zugangstoken erstellen'__.
 
 <img src={ShivaProfil003} />
 
-Sie sehen nun alle API-Schlüssel, die für diesen Benutzer in diesem Mandanten erstellt wurden. Klicken Sie auf __'Neuen persönlichen Zugangstoken erstellen'__.
+Sie sehen nun alle API-Schlüssel, die für diesen Benutzer in diesem Tenant erstellt wurden. Klicken Sie auf __'Neuen persönlichen Zugangstoken erstellen'__.
 
 <img src={ShivaProfil002} />
 
 Sie müssen nun Folgendes angeben:
 
-- Geben Sie einen Namen für diesen neuen Token an,
-- Legen Sie ein Ablaufdatum fest (maximal 12 Monate Gültigkeit),
-- Wählen Sie die Berechtigungen, die mit dem Token verknüpft werden sollen.
+- Den Namen für diesen neuen Token,
+- Ein Ablaufdatum (maximal 12 Monate Gültigkeit),
+- Die zugehörigen Berechtigungen für den Token.
 
 Anschließend werden die Details Ihres Tokens angezeigt. __Achtung: Der Zugriff auf diese Informationen ist nachträglich nicht mehr möglich.__
 
@@ -48,6 +48,15 @@ Sie sehen nun den neu erstellten Token und sein zukünftiges Ablaufdatum.
 
 <img src={ShivaProfil005} />
 
+:::info Lebenszyklus des Authentifizierungstokens
+Wenn Sie Ihren **Personal Access Token (PAT)** verwenden, um sich bei der API zu authentifizieren, erhalten Sie daraufhin einen Zugangstoken zurück. Es ist wichtig zu beachten, dass dieser Zugangstoken ein **JSON Web Token (JWT)** mit begrenzter Gültigkeitsdauer ist.
+
+-   **Gültigkeitsdauer**: Jeder JWT-Token ist für eine Dauer von **5 Minuten** gültig.
+-   **Überprüfung**: Sie können das Erstellungsdatum (`iat`) und das Ablaufdatum (`exp`) Ihres Tokens überprüfen, indem Sie es decodieren. Online-Tools wie [jwt.io](https://jwt.io) ermöglichen dies einfach.
+
+Sobald der Token abgelaufen ist, müssen Sie sich erneut mit Ihrem PAT authentifizieren, um einen neuen Token zu erhalten. Es wird daher empfohlen, diesen Lebenszyklus in Ihren Skripten und Anwendungen zu verwalten, indem Sie eine automatische Erneuerung des Tokens vorsehen.
+:::
+
 ## Access to the API Portal
 
 The OpenAPI 3.0 (Swagger) documentation for the Cloud Temple console APIs is available directly within the application:
@@ -57,7 +66,7 @@ The OpenAPI 3.0 (Swagger) documentation for the Cloud Temple console APIs is ava
 Access to the APIs requires authentication. Once authenticated, all operations must include the header  
 __'Authorization'__ with the bearer access token obtained during the authentication phase.
 
-The URLs for the endpoints are provided directly in __Swagger__ (in the "Servers" object on each API page).
+The URLs for the endpoints are directly provided in __Swagger__ (in the "Servers" object on each API page).
 
 ## Activities
 
@@ -91,7 +100,7 @@ The activity content includes all essential information needed to identify the o
 }
 ```
 
-The __state__ object can take different forms depending on the activity's status, as follows:
+The __state__ object can take different forms depending on the activity's status:
 
 __waiting__, status before the operation has started:
 
@@ -134,10 +143,10 @@ __Note: The resource's UUIDv4 identifier is available in the activity result onc
 
 The Cloud Temple console sets __caps on the number of requests__ a user can send to the API within a given time period. Implementing these rate limits is a common practice in API management, adopted for several essential reasons:
 
-- __Prevention of abuse__: These limits help safeguard the integrity of the API by preventing abusive or careless usage that could compromise its operation.
-- __Guarantee of service quality__: By regulating access to the API, we ensure a fair distribution of resources, allowing all users to enjoy a stable and high-performing experience.
+- __Prevention of abuse__: These limits help safeguard the API's integrity by preventing abusive or poorly designed usage that could compromise its operation.
+- __Guarantee of service quality__: By regulating API access, we ensure a fair distribution of resources, allowing all users to enjoy a stable and high-performing experience.
 
-Consider a poorly designed or inefficient script making repeated calls to the API, risking resource exhaustion and performance degradation. By setting request thresholds, we prevent such scenarios and ensure __a smooth, uninterrupted service__ for our entire customer base.
+Consider a poorly designed or inefficient script making repeated API calls, risking resource exhaustion and performance degradation. By setting request thresholds, we prevent such scenarios and ensure __a smooth, uninterrupted service__ for our entire customer base.
 
 ### What are the rate limits for the Cloud Temple Console API?
 
@@ -160,7 +169,7 @@ The following limits are in place:
 | Hosting | 25 r/s |
 | Marketplace | 25 r/s |
 | Support | 25 r/s |
-| Notification | 25 r/s |
+| Notifications | 25 r/s |
 | LLMaaS | 25 r/s |
 
 ### Specific Routes
@@ -195,14 +204,14 @@ It is recommended to limit the number of API calls made by your automation to st
 
 This situation often occurs when multiple requests are executed in parallel, using several processes or threads.
 
-There are several ways to improve the efficiency of your automation, including using __caching mechanisms__ and implementing a __retry system with exponential backoff__. This method involves taking a short pause when a rate limit error is encountered, then retrying the request. If the request fails again, the pause duration is progressively increased until the request succeeds or until a maximum number of retries is reached.
+There are several ways to improve the efficiency of your automation, including using __caching mechanisms__ and implementing a __retry system with exponential backoff__. This method involves taking a short pause when a rate limit error is encountered, then retrying the request. If the request fails again, the pause duration is progressively increased until the request succeeds or a maximum number of retries is reached.
 
 This approach offers several advantages:
 
-- __Exponential backoff__ ensures that initial attempts are made quickly, while longer delays are applied in case of repeated failures.
+- __Exponential backoff__ ensures that initial attempts are made quickly, while longer delays are scheduled in case of repeated failures.
 - Adding a __random variation__ to the pause helps prevent all retry attempts from occurring simultaneously.
 
-It is important to note that __failed requests do not affect your rate limit__. However, continuously retrying a request may not be a sustainable long-term solution, as this behavior could change in the future. Therefore, we recommend not relying solely on this mechanism.
+It is important to note that __failed requests do not affect your rate limit__. However, continuously retrying a request may not be a sustainable long-term solution, as this behavior could change in the future. Therefore, we recommend against relying solely on this mechanism.
 
 Python libraries __[Backoff](https://pypi.org/project/backoff/)__ and __[Tenacity](https://pypi.org/project/tenacity/)__ are excellent starting points for implementing retry strategies.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/console/api.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/console/api.md
@@ -15,7 +15,7 @@ import ShivaApi004 from './images/shiva_api_004.png'
 
 The __API key__ allows you to authenticate when making requests to the API. Generating an API key, also known as a __Personal Access Token (PAT)__, is a secure way to connect to the Shiva APIs without using a graphical interface. Each of these tokens is linked to a specific tenant and the user who created it.
 
-Creating this token is done from your account. You can generate multiple keys and configure permissions for each one, within the limits of your rights.
+Creating this token is done from your account. You can generate multiple keys and configure permissions for each one, within the limits of your access rights.
 
 To create an API key, simply __click on your profile__:
 
@@ -47,7 +47,16 @@ You will then see the newly created token and its future expiration date.
 
 <img src={ShivaProfil005} />
 
-## API Portal Access
+:::info Token Authentication Lifecycle
+When you use your **Personal Access Token (PAT)** to authenticate with the API, you receive in return an access token. It is important to note that this access token is a **JSON Web Token (JWT)** with a limited lifespan.
+
+-   **Lifespan**: Each JWT token is valid for **5 minutes**.
+-   **Verification**: You can check the issuance date (`iat`) and expiration date (`exp`) of your token by decoding it. Online tools such as [jwt.io](https://jwt.io) make this easy.
+
+Once the token expires, you must re-authenticate using your PAT to obtain a new one. Therefore, it is recommended to manage this lifecycle in your scripts and applications by implementing automatic token renewal.
+:::
+
+## Access to the API Portal
 
 The OpenAPI 3.0 (Swagger) documentation for the Cloud Temple console APIs is available directly within the application:
 
@@ -60,7 +69,7 @@ The API endpoint URLs are directly provided in __Swagger__ (within the "Servers"
 
 ## Activities
 
-Tracking of write-type requests (POST, PUT, PATCH, DELETE) is handled through activity management. Each request of this type automatically generates a corresponding activity. A HTTP status code 201 confirms the successful creation of the activity. The unique identifier of this activity is returned in the response headers under the key 'Location'.
+Tracking of write-type requests (POST, PUT, PATCH, DELETE) is handled through activity management. Each such request automatically generates a corresponding activity. A HTTP status code 201 confirms the successful creation of the activity. The unique identifier of this activity is returned in the response headers under the key 'Location'.
 
 <img src={ShivaApi002} />
 
@@ -134,15 +143,15 @@ __Note: The resource's UUIDv4 identifier is available in the activity result onc
 The Cloud Temple console sets __caps on the volume of requests__ an individual user can send to the API within a given time period. Implementing these rate limits is a common practice in API management, adopted for several essential reasons:
 
 - __Prevention of abuse__: These limits help safeguard the API's integrity by preventing abusive or poorly designed usage that could compromise its operation.
-- __Guarantee of service quality__: By regulating API access, we ensure a fair distribution of resources, enabling all users to enjoy a stable and high-performing experience.
+- __Guarantee of service quality__: By regulating API access, we ensure a fair distribution of resources, allowing all users to enjoy a stable and high-performing experience.
 
-Consider a poorly designed or inefficient script making repeated API calls—such behavior risks overwhelming system resources and degrading performance. By establishing request thresholds, we prevent such scenarios and ensure the maintenance of a __smooth, uninterrupted service__ for our entire user base.
+Consider a poorly designed or inefficient script making repeated calls to the API—this could overwhelm system resources and degrade performance. By setting request thresholds, we prevent such scenarios and ensure a __smooth, uninterrupted service__ for our entire user base.
 
-### What are the rate limits for the Cloud Temple Console API?
+### What are the rate limits for the Cloud Temple console API?
 
 We apply quantitative restrictions on user interactions with the console for each product.
 
-Limits are defined in __requests per second (r/s) per source IP__. Once the threshold is exceeded, the system responds with an HTTP 429 error code, indicating that the allowed request limit has been surpassed.
+Limits are defined in __requests per second (r/s) and per source IP__. Once the threshold is exceeded, the system responds with an HTTP 429 error code, indicating that the allowed request limit has been surpassed.
 
 Here are the defined limits:
 
@@ -164,7 +173,7 @@ Here are the defined limits:
 
 ### Specific Routes
 
-Certain API endpoints, particularly those related to authentication or sensitive operations, have more restrictive limits to enhance security and ensure stability.
+Certain specific API endpoints, particularly those related to authentication or sensitive operations, have more restrictive limits to enhance security and ensure stability.
 
 | Route | Limit Threshold |
 |---|---|
@@ -201,9 +210,9 @@ This approach offers several advantages:
 - __Exponential backoff__ ensures that initial attempts are made quickly, while longer delays are applied in case of repeated failures.
 - Adding a __random variation__ to the pause helps prevent all retry attempts from occurring simultaneously.
 
-It is important to note that __failed requests do not count toward your rate limit__. However, continuously retrying a request may not be a sustainable long-term solution, as this behavior could change in the future. Therefore, we recommend not relying solely on this mechanism.
+It is important to note that __failed requests do not count toward your rate limit__. However, continuously retrying a request may not be a sustainable long-term solution, as this behavior could change in the future. Therefore, we recommend against relying solely on this mechanism.
 
-Python libraries __[Backoff](https://pypi.org/project/backoff/)__ and __[Tenacity](https://pypi.org/project/tenacity/)__ are excellent starting points for implementing retry strategies with backoff.
+Python libraries __[Backoff](https://pypi.org/project/backoff/)__ and __[Tenacity](https://pypi.org/project/tenacity/)__ are excellent starting points for implementing retry strategies.
 
 ## API Endpoint Lifecycle
 
@@ -211,7 +220,7 @@ Information about the evolution of API endpoints is available in the release not
 
 <img src={ShivaApi004} />
 
-You will find a list of endpoints that are deprecated, organized by activity.
+You will find a list of deprecated endpoints, organized by activity.
 
 Additionally, deprecated endpoints will appear in our API as follows:  
 __~~this/is/an/endpoint~~__ along with a definitive deletion date in the description.

--- a/i18n/es/docusaurus-plugin-content-docs/current/console/api.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/console/api.md
@@ -13,7 +13,8 @@ import ShivaApi004 from './images/shiva_api_004.png'
 
 ## Claves API
 
-La __clave API__ permite autenticarse cuando desea realizar solicitudes a la API. La generación de una clave API, también conocida como __Personal Access Token (PAT)__, es una forma segura de conectarse a las API de Shiva sin necesidad de usar una interfaz gráfica. Cada uno de estos tokens está vinculado a un inquilino y al usuario que lo creó.
+La __clave API__ permite autenticarse cuando desea realizar solicitudes a la API. La generación de una clave API, también conocida como __Personal Access Token (PAT)__,
+es una forma segura de conectarse a las API de Shiva sin necesidad de utilizar una interfaz gráfica. Cada uno de estos tokens está vinculado a un inquilino y al usuario que lo creó.
 
 La creación de este token se realiza desde su cuenta. Es posible generar varias claves y configurar los permisos para cada una, dentro de los límites de sus derechos.
 
@@ -29,23 +30,32 @@ A continuación, verá en pantalla el conjunto de claves API que han sido creada
 
 <img src={ShivaProfil002} />
 
-A continuación, deberá:
+Debe entonces:
 
 - Indicar el nombre de este nuevo token,
-- Establecer una fecha de caducidad (máximo 12 meses de validez),
+- Indicar una fecha de expiración (máximo 12 meses de validez),
 - Seleccionar los permisos asociados al token.
 
-A continuación, se mostrarán los detalles de su token. __Atención, ya no será posible acceder a esta información posteriormente.__
+A continuación, se muestran los detalles de su token. __Atención, no será posible acceder a esta información posteriormente.__
 
-Si no anota esta información, deberá destruir y volver a crear el token.
+Si no anota esta información, deberá destruir y recrear el token.
 
 <img src={ShivaProfil004} />
 
 Por razones de seguridad, se recomienda crear varios tokens, cada uno con una función específica (un token para cada aplicación o proceso empresarial), en lugar de crear un solo token con todos los permisos.
 
-A continuación, verá el nuevo token creado y su fecha futura de caducidad.
+A continuación, verá el nuevo token creado y su fecha futura de expiración.
 
 <img src={ShivaProfil005} />
+
+:::info Ciclo de vida del token de autenticación
+Cuando utiliza su **Personal Access Token (PAT)** para autenticarse ante la API, recibe a cambio un token de acceso. Es importante destacar que este token de acceso es un **JSON Web Token (JWT)** con una duración limitada.
+
+-   **Duración de vida**: Cada token JWT es válido durante un período de **5 minutos**.
+-   **Verificación**: Puede verificar la fecha de emisión (`iat`) y la fecha de expiración (`exp`) de su token decodificándolo. Herramientas en línea como [jwt.io](https://jwt.io) le permiten hacerlo fácilmente.
+
+Una vez que el token ha expirado, deberá volver a autenticarse con su PAT para obtener uno nuevo. Por ello, se recomienda gestionar este ciclo de vida en sus scripts y aplicaciones, previendo una renovación automática del token.
+:::
 
 ## Acceso al portal de API
 
@@ -90,7 +100,7 @@ El contenido de la actividad incluye todas las informaciones esenciales para ide
 }
 ```
 
-El objeto __state__ puede tomar diferentes formas según el estado de la actividad, a saber:
+El objeto __state__ puede adoptar diferentes formas según el estado de la actividad, a saber:
 
 __waiting__, estado antes de que la operación haya comenzado:
 
@@ -143,7 +153,7 @@ Tomemos como ejemplo un script mal diseñado o ineficiente que realiza llamadas 
 Aplicamos restricciones cuantitativas sobre las interacciones de los usuarios con la consola  
 para cada producto.
 
-Los límites están definidos en __consultas por segundo (r/s) y por dirección IP de origen__. Más allá del umbral límite, el sistema responderá  
+Los límites están definidos en __consultas por segundo (r/s) y por dirección IP de origen__. Por encima del umbral límite, el sistema responderá  
 con un código de error HTTP 429, indicando que se ha superado el límite de consultas permitidas.
 
 A continuación se indican los límites establecidos:
@@ -166,7 +176,7 @@ A continuación se indican los límites establecidos:
 
 ### Specific routes
 
-Certain specific API endpoints, particularly those related to authentication or sensitive actions, have more restrictive limits to enhance security and ensure stability.
+Certain API endpoints, particularly those related to authentication or sensitive actions, have more restrictive limits to enhance security and ensure stability.
 
 | Route | Limit threshold |
 |---|---|
@@ -174,12 +184,12 @@ Certain specific API endpoints, particularly those related to authentication or 
 | IaaS - Storage (Datastores) | 20 r/s |
 | Marketplace (Contact) | 1 r/min - 5 r/h |
 
-### ¿Cómo funcionan los límites de tasa?
+### How do rate limits work?
 
-Si el número de solicitudes enviadas a un punto de API supera el límite permitido, el punto de API responderá devolviendo  
-__un código de respuesta HTTP 429__. Este código indica que el usuario ha excedido el número de solicitudes permitidas.  
-Cuando esto ocurre, el punto de API también proporcionará un objeto JSON como respuesta,  
-que contendrá información detallada sobre la limitación aplicada:
+If the number of requests sent to an API endpoint exceeds the allowed limit, the API endpoint will respond by returning  
+__an HTTP 429 status code__. This code indicates that the user has exceeded the permitted number of requests.  
+When this happens, the API endpoint will also provide a JSON object as a response,  
+containing detailed information about the applied rate limit:
 
 ```
     {
@@ -194,18 +204,18 @@ que contendrá información detallada sobre la limitación aplicada:
 
 Se recomienda limitar el número de llamadas a la API realizadas por su automatización para permanecer por debajo del límite de tasa establecido para el punto final.
 
-Esta situación suele ocurrir cuando se ejecutan varias solicitudes en paralelo, utilizando varios procesos o hilos.
+Esta situación suele ocurrir cuando varias solicitudes se ejecutan en paralelo, utilizando varios procesos o hilos.
 
-Existen varios métodos para mejorar la eficiencia de su automatización, incluyendo el uso de mecanismos de __almacenamiento en caché__ y la implementación de un __sistema de reintento con amortiguación progresiva__. Este método consiste en realizar una breve pausa cuando se encuentra un error de límite de tasa, y luego intentar nuevamente la solicitud. Si la solicitud falla nuevamente, la duración de la pausa se aumenta progresivamente hasta que la solicitud tenga éxito o se alcance un número máximo de intentos.
+Existen varios métodos para mejorar la eficiencia de su automatización, incluyendo el uso de mecanismos de __caché__ y la implementación de un __sistema de reintento con amortiguamiento progresivo__. Este método consiste en realizar una breve pausa cuando se detecta un error de límite de tasa, y luego intentar nuevamente la solicitud. Si la solicitud falla nuevamente, la duración de la pausa se aumenta progresivamente hasta que la solicitud tenga éxito o hasta que se alcance un número máximo de intentos.
 
 Esta aproximación ofrece numerosas ventajas:
 
-- La __amortiguación progresiva__ garantiza que los primeros intentos se realicen rápidamente, mientras que prevé tiempos de espera más largos en caso de fallos repetidos.
+- El __amortiguamiento progresivo__ garantiza que los primeros intentos se realicen rápidamente, mientras que prevé tiempos de espera más largos en caso de fallos repetidos.
 - La adición de una __variación aleatoria__ a la pausa ayuda a evitar que todos los intentos se produzcan simultáneamente.
 
 Es importante tener en cuenta que las __solicitudes fallidas no afectan su límite de tasa__. Sin embargo, reenviar continuamente una solicitud podría no ser una solución viable a largo plazo, ya que este comportamiento podría modificarse en el futuro. Por ello, le recomendamos no depender exclusivamente de este mecanismo.
 
-Las bibliotecas __[Backoff](https://pypi.org/project/backoff/)__ y __[Tenacity](https://pypi.org/project/tenacity/)__ en Python son buenos puntos de partida para implementar estrategias de amortiguación.
+Las bibliotecas __[Backoff](https://pypi.org/project/backoff/)__ y __[Tenacity](https://pypi.org/project/tenacity/)__ en Python son buenos puntos de partida para implementar estrategias de amortiguamiento.
 
 ## Lifecycle of an API endpoint
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/console/api.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/console/api.md
@@ -13,39 +13,49 @@ import ShivaApi004 from './images/shiva_api_004.png'
 
 ## Chiavi API
 
-La __chiave API__ permet di autenticarsi quando si desidera effettuare richieste sull'API. La generazione di una chiave API, nota anche come __Personal Access Token (PAT)__, è un modo sicuro per connettersi alle API Shiva senza dover passare attraverso un'interfaccia grafica. Ogni token è associato a un tenant e all'utente che lo ha creato.
+La __chiave API__ permet di autenticarsi quando si desidera effettuare richieste all'API. La generazione di una chiave API, nota anche come __Personal Access Token (PAT)__,
+è un modo sicuro per connettersi alle API Shiva senza dover passare attraverso un'interfaccia grafica. Ogni token è associato a un tenant e all'utente che lo ha creato.
 
-La creazione di questo token avviene dal tuo account. È possibile generare più chiavi e configurare per ciascuna le autorizzazioni, entro i limiti dei tuoi diritti.
+La creazione di questo token avviene dal tuo account. È possibile generare più chiavi e configurare per ciascuna le autorizzazioni entro i limiti dei tuoi diritti.
 
 Per creare una chiave API, è sufficiente __fare clic sul tuo profilo__:
 
 <img src={ShivaProfil001} />
 
-Nel menu del profilo, fare clic su __'Token di accesso personale'__.
+Nel menu del profilo, fare clic su __'Token di accesso personale'__
 
 <img src={ShivaProfil003} />
 
-A questo punto, sullo schermo verranno visualizzate tutte le chiavi API create per questo utente in questo tenant. Fare clic su __'Nuovo token di accesso personale'__.
+A questo punto, sullo schermo verranno visualizzate tutte le chiavi API create per questo utente in questo tenant. Fare clic su __'Nuovo token di accesso personale'__
 
 <img src={ShivaProfil002} />
 
-È quindi necessario:
+Devi quindi:
 
-- Inserire un nome per questo nuovo token,
+- Inserire il nome di questo nuovo token,
 - Specificare una data di scadenza (massimo 12 mesi di validità),
-- Selezionare le autorizzazioni associate al token.
+- Scegliere le autorizzazioni associate al token.
 
-Verranno quindi visualizzati i dettagli relativi al token. __Attenzione: non sarà più possibile accedervi successivamente.__
+Verranno quindi visualizzati i dettagli relativi al tuo token. __Attenzione, non sarà più possibile accedervi successivamente.__
 
-Se non si annotano queste informazioni, sarà necessario eliminare e ricreare il token.
+Se non annoti queste informazioni, dovrai distruggere e ricreare il token.
 
 <img src={ShivaProfil004} />
 
-Per ragioni di sicurezza, si raccomanda di creare più token, ciascuno con una funzione specifica (un token per ogni applicazione o processo aziendale), piuttosto che creare un unico token con tutti i permessi.
+Per ragioni di sicurezza, si raccomanda di creare più token, ciascuno con una funzione specifica (un token per ogni applicazione o processo aziendale), piuttosto che creare un singolo token con tutti i diritti.
 
-Verrà quindi visualizzato il nuovo token creato e la relativa data di scadenza futura.
+Vedi quindi il nuovo token creato e la sua futura data di scadenza.
 
 <img src={ShivaProfil005} />
+
+:::info Ciclo di vita del token di autenticazione
+Quando utilizzi il tuo **Personal Access Token (PAT)** per autenticarti presso l'API, ricevi in risposta un token di accesso. È importante notare che questo token di accesso è un **JSON Web Token (JWT)** con una durata di vita limitata.
+
+-   **Durata di vita**: Ogni token JWT è valido per una durata di **5 minuti**.
+-   **Verifica**: Puoi verificare la data di emissione (`iat`) e la data di scadenza (`exp`) del tuo token decodificandolo. Strumenti online come [jwt.io](https://jwt.io) ti permettono di farlo facilmente.
+
+Una volta scaduto il token, dovrai autenticarti nuovamente con il tuo PAT per ottenerne uno nuovo. È quindi consigliabile gestire questo ciclo di vita nei tuoi script e applicazioni prevedendo un aggiornamento automatico del token.
+:::
 
 ## Accesso al portale API
 
@@ -97,7 +107,7 @@ __waiting__, stato prima che l'operazione abbia iniziato:
 ```
     waiting: {}
 ```
-__running__, stato quando l'operazione è in corso:
+__running__, stato durante l'esecuzione dell'operazione:
 
 ```
     running: {
@@ -106,7 +116,7 @@ __running__, stato quando l'operazione è in corso:
     progression: number;
     };
 ```
-__failed__, stato se l'operazione ha fallito:
+__failed__, stato se l'operazione ha avuto esito negativo:
 
 ```
     failed: {
@@ -131,22 +141,22 @@ __Nota: l'identificativo (UUIDv4) della risorsa creata è disponibile nel risult
 
 ### Perché limiti?
 
-La console Cloud Temple definisce __un limite massima sul volume di richieste__ che un utente può inviare all'API in un determinato periodo di tempo. L'implementazione di questi limiti di frequenza è una pratica comune nella gestione delle API, adottata per diversi motivi fondamentali:
+La console Cloud Temple stabilisce __un limite massima sul volume di richieste__ che un utente può inviare all'API in un determinato periodo di tempo. L'implementazione di questi limiti di frequenza è una pratica comune nella gestione delle API, adottata per diversi motivi fondamentali:
 
 - __Prevenzione degli abusi__: Questi limiti contribuiscono a preservare l'integrità dell'API prevenendo utilizzi abusivi o inadeguati che potrebbero comprometterne il funzionamento.
 - __Garanzia della qualità del servizio__: Regolando l'accesso all'API, garantiamo una distribuzione equa delle risorse, permettendo a tutti gli utenti di godere di un'esperienza stabile e performante.
 
-Consideriamo ad esempio uno script mal progettato o inefficiente che effettua chiamate ripetute all'API, con il rischio di saturare le risorse e degradare le prestazioni. Stabilendo soglie di richieste, preveniamo tali situazioni e garantiamo il mantenimento di un __servizio fluido e continuo__ per l'intera clientela.
+Prendiamo ad esempio uno script mal progettato o inefficiente che tenta chiamate ripetute all'API, rischiando di saturare le risorse e degradare le prestazioni. Stabilendo soglie di richieste, preveniamo queste situazioni e garantiamo il mantenimento di un __servizio fluido e continuo__ per l'intera clientela.
 
 ### Quali sono i limiti di velocità per l'API della console Cloud Temple?
 
 Applichiamo restrizioni quantitative sulle interazioni degli utenti con la console per ogni prodotto.
 
-I limiti sono definiti in __richieste al secondo (r/s) e per indirizzo IP sorgente__. Oltre al limite massimo, il sistema risponderà con un codice di errore HTTP 429, indicando che il limite massimo di richieste consentite è stato superato.
+I limiti sono definiti in __richieste al secondo (r/s) e per indirizzo IP sorgente__. Oltre la soglia limite, il sistema risponderà con un codice di errore HTTP 429, indicando che il limite massimo di richieste consentite è stato superato.
 
 Ecco i limiti definiti:
 
-| Prodotto | Soglia massima |
+| Prodotto | Soglia limite |
 |---|---|
 | Console Cloud Temple | 25 r/s |
 | Identità (IAM) | 25 r/s |
@@ -199,9 +209,9 @@ Esistono diversi modi per migliorare l'efficienza della propria automazione, in 
 Questo approccio presenta numerosi vantaggi:
 
 - L'__attenuazione progressiva__ garantisce che i primi tentativi vengano eseguiti rapidamente, prevedendo tempi di attesa più lunghi in caso di fallimenti ripetuti.
-- L'aggiunta di una __variazione casuale__ alla pausa contribuisce a evitare che tutti i tentativi avvengano simultaneamente.
+- L'aggiunta di una __variazione casuale__ alla pausa contribuisce a evitare che tutti i tentativi si verifichino simultaneamente.
 
-È importante notare che le __richieste non riuscite non influiscono sul proprio limite di frequenza__. Tuttavia, inviare continuamente una richiesta potrebbe non essere una soluzione sostenibile a lungo termine, poiché questo comportamento potrebbe essere modificato in futuro. Vi raccomandiamo quindi di non basarvi esclusivamente su questo meccanismo.
+È importante notare che le __richieste non riuscite non influenzano il proprio limite di frequenza__. Tuttavia, inviare continuamente una richiesta potrebbe non essere una soluzione sostenibile a lungo termine, poiché questo comportamento potrebbe essere modificato in futuro. Vi raccomandiamo quindi di non basarvi esclusivamente su questo meccanismo.
 
 Le librerie __[Backoff](https://pypi.org/project/backoff/)__ e __[Tenacity](https://pypi.org/project/tenacity/)__ in Python sono buoni punti di partenza per implementare strategie di attenuazione.
 


### PR DESCRIPTION
This PR addresses issue #127 by adding details about the 5-minute lifecycle of JWTs generated from a Personal Access Token (PAT).