### PR TITLE
📝 docs(storage/oss): précision chiffrement D@RE — module AES-256 validé FIPS 140-3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Suivi des Changements
 
+### 15 Juillet 2026 : Précision sur le chiffrement du Stockage Objet
+
+- **Stockage Objet (Sécurité)** : La section sur le chiffrement des données au repos (D@RE) précise désormais que le chiffrement AES-256 repose sur un module cryptographique validé selon la norme FIPS 140-3.
+
 ### 26 Mai 2026 : Amélioration du workflow de traduction
 
 - **Traduction (outillage)** : Ajout des options `--token`, `--url` et `--model` au script Python `scripts/translate_py/translate.py`. Le token API peut désormais être fourni directement en ligne de commande, sans recréer de fichier `.env`. Les options CLI sont prioritaires sur les variables d'environnement.

--- a/docs/storage/oss/concepts.md
+++ b/docs/storage/oss/concepts.md
@@ -27,7 +27,7 @@ La sécurité de vos données est notre priorité absolue. Le service OSS intèg
 Pour protéger vos données stockées, notre service utilise le chiffrement côté serveur.
 
 - **Activation** : Le chiffrement D@RE est activé au niveau du *namespace* (espace de nommage).
-- **Algorithme** : Nous utilisons l'algorithme **AES-256**, l'un des standards de chiffrement les plus forts disponibles.
+- **Algorithme** : Les données sont chiffrées avec **AES-256**, l'un des standards de chiffrement symétrique les plus robustes. Sa mise en œuvre repose sur un module cryptographique logiciel validé selon la norme **FIPS 140-3**.
 - **Fonctionnement** : Lorsque vous écrivez un objet dans un bucket où D@RE est activé, le service chiffre automatiquement vos données avant de les écrire sur les disques. Lorsque vous lisez l'objet, il est déchiffré de manière transparente pour vous. La gestion des clés de chiffrement est entièrement prise en charge par le service.
 
 ### Chiffrement des Données en Transit


### PR DESCRIPTION
Enrichit la section « Data at Rest Encryption » de docs/storage/oss/concepts.md : la mise en œuvre AES-256 repose sur un module cryptographique validé FIPS 140-3.

Formulation générique conforme à la règle éditoriale n°4 (pas d'exposition du composant logiciel interne ni de sa version) et à l'attribution FIPS correcte (le module est validé, pas l'algorithme). Entrée changelog ajoutée.