### PR TITLE
docs(storage): préciser l'algorithme de chiffrement Object Storage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Suivi des Changements
 
+### 15 Juillet 2026 : Précision sur le chiffrement Object Storage
+
+- **Object Storage (Sécurité)** : La section sur le chiffrement des données au repos (D@RE) précise désormais que le service utilise un chiffrement AES 256 bits certifié FIPS 140-3, via la bibliothèque logicielle RSA BSAFE Crypto-J en version 7.x.
+
 ### 26 Mai 2026 : Amélioration du workflow de traduction
 
 - **Traduction (outillage)** : Ajout des options `--token`, `--url` et `--model` au script Python `scripts/translate_py/translate.py`. Le token API peut désormais être fourni directement en ligne de commande, sans recréer de fichier `.env`. Les options CLI sont prioritaires sur les variables d'environnement.

--- a/docs/storage/oss/concepts.md
+++ b/docs/storage/oss/concepts.md
@@ -27,7 +27,7 @@ La sécurité de vos données est notre priorité absolue. Le service OSS intèg
 Pour protéger vos données stockées, notre service utilise le chiffrement côté serveur.
 
 - **Activation** : Le chiffrement D@RE est activé au niveau du *namespace* (espace de nommage).
-- **Algorithme** : Nous utilisons l'algorithme **AES-256**, l'un des standards de chiffrement les plus forts disponibles.
+- **Algorithme** : Nous utilisons un chiffrement **AES 256 bits** certifié **FIPS 140-3**, via la bibliothèque logicielle **RSA BSAFE Crypto-J** en version **7.x**.
 - **Fonctionnement** : Lorsque vous écrivez un objet dans un bucket où D@RE est activé, le service chiffre automatiquement vos données avant de les écrire sur les disques. Lorsque vous lisez l'objet, il est déchiffré de manière transparente pour vous. La gestion des clés de chiffrement est entièrement prise en charge par le service.
 
 ### Chiffrement des Données en Transit


### PR DESCRIPTION
## Résumé

- Précise l'algorithme de chiffrement D@RE dans la documentation publique Object Storage.
- Ajoute la mention AES 256 bits, FIPS 140-3 et RSA BSAFE Crypto-J 7.x.
- Ajoute l'entrée correspondante dans `docs/changelog.md`.

## Traduction

- `python3 scripts/translate_py/translate.py --dry-run --debug --no-debug-system-prompt` OK : 8 tâches détectées pour `storage/oss/concepts.md` et `changelog.md` vers en/de/es/it.
- Traduction réelle lancée avec `python3 scripts/translate_py/translate.py`, mais bloquée par l'absence de `CLOUDTEMPLE_API_KEY` dans l'environnement.
- Les fichiers `i18n/` n'ont pas été édités manuellement, conformément aux règles du repo.

## Vérifications

- Recherche PR existante : aucune PR ouverte trouvée sur le sujet.
- Diff limité à `docs/storage/oss/concepts.md` et `docs/changelog.md`.
- `git diff --check` OK.