### PR TITLE
docs(console): vue organisation et gestion des tenants dans le quickstart

### DIFF
--- a/docs/console/console_quickstart.md
+++ b/docs/console/console_quickstart.md
@@ -159,6 +159,15 @@ Les droits des utilisateurs se définissent __tenant par tenant__ : un même com
 Cette page décrit le parcours dans la Console. Pour la référence détaillée — définitions, cycle de vie, fédération d'identité et liste exhaustive des permissions — reportez-vous au module IAM : [Concepts](iam/concepts.md) et [Guide de démarrage IAM](iam/quickstart.md).
 :::
 
+### Le module Administration en un coup d'œil
+
+Le module __Administration__ regroupe quatre menus :
+
+- __Support__ : consultez et suivez vos dossiers de support pour le tenant (permissions `support_read`, `support_write`, `support_management`). La création d'un dossier est décrite dans la section « Accès au support technique » ci-dessus.
+- __Utilisateurs__ : invitez les comptes de votre organisation et attribuez leurs permissions tenant par tenant (permissions `iam_read`, `iam_write`). Détaillé ci-dessous.
+- __Logs__ : journal des opérations de lecture et d'écriture réalisées dans la Console, à des fins de traçabilité (permission `activity_read`). Détaillé dans « Journalisation » ci-dessous.
+- __Accès__ : gérez la liste blanche des adresses IP publiques autorisées à accéder à la Console (permissions `console_public_access_read`, `console_public_access_write`). Détaillé ci-dessous.
+
 ### Sélectionner le tenant de travail
 
 Le sélecteur de tenant est situé en haut à gauche de la Console. Il permet de basculer d'un périmètre à l'autre ; les tenants qualifiés affichent le badge __SecNumCloud__.
@@ -184,6 +193,17 @@ Conformément à la qualification SecNumCloud, l'accès à la Console est limit�
 - Consultation de la liste : permission `console_public_access_read`.
 - Ajout d'une adresse : permission `console_public_access_write`.
 - La __suppression__ d'une IP autorisée se fait par une demande de support.
+
+### Commander et gérer les produits d'un tenant
+
+Les ressources et produits (calcul, stockage, réseau, bastion, colocation…) se commandent depuis le module __Commande__ (permission `order_read` pour le suivi, `order_write` pour la création) et sont __affectés à un tenant précis__ : ils ne sont pas partagés avec les autres tenants. Le suivi des déploiements se fait dans ce même module (le tableau de bord du tenant affiche les commandes en cours).
+
+- __Initialisation__ : un tenant ne peut pas être vide ; il démarre avec au minimum une zone de disponibilité, un cluster de calcul, un espace de stockage et un VLAN réseau.
+- __Évolution__ : vous ajoutez ou retirez des ressources en passant de nouvelles commandes, et vous pouvez faire évoluer l'architecture en ajoutant ou supprimant des tenants.
+- __Réseaux inter-tenants__ : pour assurer la continuité réseau entre tenants, des réseaux « cross tenant » peuvent être demandés.
+- __Droits__ : un propriétaire du tenant dispose automatiquement de toutes les permissions des produits activés sur ce tenant (voir ci-dessous).
+
+Le parcours de commande détaillé est décrit dans [Commandes](orders.md) ; la définition et les références d'activation d'un tenant figurent dans [Tenant](iam/concepts.md#tenant).
 
 ### Propriétaires et cycle de vie d'un tenant
 

--- a/docs/console/console_quickstart.md
+++ b/docs/console/console_quickstart.md
@@ -16,6 +16,8 @@ import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_cr
 import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
 import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
 import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
+import shivaOrdersList from '@site/docs/console/images/shiva_orders_list.png'
+import shivaOrdersIaasCpoolEsx from '@site/docs/console/images/shiva_orders_iaas_cpool_esx.png'
 
 ## Prérequis
 
@@ -194,16 +196,30 @@ Conformément à la qualification SecNumCloud, l'accès à la Console est limit�
 - Ajout d'une adresse : permission `console_public_access_write`.
 - La __suppression__ d'une IP autorisée se fait par une demande de support.
 
-### Commander et gérer les produits d'un tenant
+### La page Support
 
-Les ressources et produits (calcul, stockage, réseau, bastion, colocation…) se commandent depuis le module __Commande__ (permission `order_read` pour le suivi, `order_write` pour la création) et sont __affectés à un tenant précis__ : ils ne sont pas partagés avec les autres tenants. Le suivi des déploiements se fait dans ce même module (le tableau de bord du tenant affiche les commandes en cours).
+Depuis __Administration > Support__, vous consultez et suivez vos __dossiers de support__ rattachés au tenant : demandes de conseil, assistance liée au compte, incidents et demandes de service professionnel. Les permissions associées sont `support_read` (consulter ses propres dossiers), `support_write` (créer un dossier) et `support_management` (consulter l'ensemble des dossiers du tenant). La création pas à pas d'un dossier est décrite dans la section « Accès au support technique » plus haut.
+
+### Créer et mettre à jour les produits d'un tenant
+
+Les produits et ressources d'un tenant (calcul, stockage, réseau, bastion, colocation…) se pilotent depuis le module __Commande__ (permission `order_read` pour le suivi, `order_write` pour la création). Toute ressource commandée est __affectée à un tenant précis__ et n'est pas partagée avec les autres.
+
+<img src={shivaOrdersList} />
+
+__Créer un produit ou une ressource__ : depuis le module __Commande__, sélectionnez le tenant cible puis le produit à activer (zone de disponibilité, cluster de calcul, cluster de stockage, réseau…). La commande est validée puis déployée ; son avancement est visible dans la liste des commandes et sur le tableau de bord du tenant.
+
+__Mettre à jour ou faire évoluer__ : l'ajout de capacité à un produit existant passe également par une commande — par exemple ajouter un hyperviseur ou de la mémoire à un cluster de calcul, un datastore à un cluster de stockage, ou un nouveau réseau.
+
+<img src={shivaOrdersIaasCpoolEsx} />
+
+Rappels de cycle de vie :
 
 - __Initialisation__ : un tenant ne peut pas être vide ; il démarre avec au minimum une zone de disponibilité, un cluster de calcul, un espace de stockage et un VLAN réseau.
 - __Évolution__ : vous ajoutez ou retirez des ressources en passant de nouvelles commandes, et vous pouvez faire évoluer l'architecture en ajoutant ou supprimant des tenants.
 - __Réseaux inter-tenants__ : pour assurer la continuité réseau entre tenants, des réseaux « cross tenant » peuvent être demandés.
 - __Droits__ : un propriétaire du tenant dispose automatiquement de toutes les permissions des produits activés sur ce tenant (voir ci-dessous).
 
-Le parcours de commande détaillé est décrit dans [Commandes](orders.md) ; la définition et les références d'activation d'un tenant figurent dans [Tenant](iam/concepts.md#tenant).
+Le détail de chaque type de commande (zone de disponibilité, clusters, stockage, réseaux, ajout d'hyperviseurs ou de mémoire…) est documenté dans [Commandes](orders.md) ; la définition et les références d'activation d'un tenant figurent dans [Tenant](iam/concepts.md#tenant).
 
 ### Propriétaires et cycle de vie d'un tenant
 

--- a/docs/console/console_quickstart.md
+++ b/docs/console/console_quickstart.md
@@ -13,6 +13,9 @@ import shivaLogs from '@site/docs/console/images/shiva_logs.png'
 import shivaOnboard_009 from '@site/docs/console/images/shiva_onboard_009.png'
 import shivaOnboard_008 from '@site/docs/console/images/shiva_onboard_008.png'
 import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_criticities.png'
+import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
+import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
+import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
 
 ## Prérequis
 
@@ -142,6 +145,53 @@ Voici une présentation des différents modules disponibles. De nouveaux modules
 </div>
 </div>
 Les pictogrammes __'NEW'__ signifient que le produit en question a été provisionné mais n'est pas encore qualifié __offre SecNumCloud__ et __'BETA'__ signifient que le produit en question a été provisionné et vient d'être qualifié __offre SecNumCloud__.
+
+## Administration : votre organisation et vos tenants
+
+Le module __Administration__ (en bas du bandeau vert, à gauche) regroupe le pilotage de votre __organisation__ et de vos __tenants__ : sélection du périmètre de travail, gestion des utilisateurs et de leurs droits, restriction des accès par IP et journalisation.
+
+- L'__organisation__ est votre entité contractuelle : elle porte les comptes utilisateurs, le mécanisme d'authentification (référentiel local ou fédération d'identité) et fédère l'ensemble de vos tenants.
+- Un __tenant__ est un regroupement de ressources cloisonné au sein de l'organisation (Production, Préproduction, par application, par criticité…). Les ressources d'un tenant ne sont pas partagées avec les autres.
+
+Les droits des utilisateurs se définissent __tenant par tenant__ : un même compte peut, par exemple, commander des ressources sur un tenant et seulement les consulter sur un autre.
+
+:::info
+Cette page décrit le parcours dans la Console. Pour la référence détaillée — définitions, cycle de vie, fédération d'identité et liste exhaustive des permissions — reportez-vous au module IAM : [Concepts](iam/concepts.md) et [Guide de démarrage IAM](iam/quickstart.md).
+:::
+
+### Sélectionner le tenant de travail
+
+Le sélecteur de tenant est situé en haut à gauche de la Console. Il permet de basculer d'un périmètre à l'autre ; les tenants qualifiés affichent le badge __SecNumCloud__.
+
+<img src={shivaTenant} />
+
+La création d'un tenant se fait par une demande de service (voir [Création d'un tenant](iam/quickstart.md#tenant)). Un tenant ne peut pas être vide : il est initialisé avec au minimum une zone de disponibilité, un cluster de calcul, un espace de stockage et un VLAN réseau.
+
+### Gérer les utilisateurs et leurs permissions
+
+Depuis __Administration > Utilisateurs__, vous invitez un utilisateur par e-mail, puis vous lui attribuez ses permissions __pour chaque tenant__. Par défaut, un compte ne possède aucun droit ; l'attribution nécessite la permission `iam_write`.
+
+<img src={shivaOnboard_005} />
+
+Les permissions sont __unitaires__ (elles ne se chevauchent pas) et __cumulatives__ : une action peut exiger plusieurs permissions (par exemple `..._read` __et__ `..._write`). La procédure complète et la [liste exhaustive des permissions](iam/concepts.md#permissions) sont documentées dans le module IAM.
+
+### Restreindre les accès : IP autorisées (Whitelist IP)
+
+Conformément à la qualification SecNumCloud, l'accès à la Console est limité aux adresses IP publiques préalablement déclarées. Depuis __Administration > Accès__, vous consultez et ajoutez les IP et subnets autorisés.
+
+<img src={shivaIpAccessManagement_01} />
+
+- Consultation de la liste : permission `console_public_access_read`.
+- Ajout d'une adresse : permission `console_public_access_write`.
+- La __suppression__ d'une IP autorisée se fait par une demande de support.
+
+### Propriétaires et cycle de vie d'un tenant
+
+Chaque tenant possède au moins un __propriétaire__, qui dispose automatiquement de toutes les permissions des produits activés sur ce tenant. Ces permissions ne sont pas modifiables, et l'interface signale au-delà de 3 propriétaires afin d'inciter au moindre privilège. Le retrait d'un propriétaire passe par une demande de support (voir [Gestion des propriétaires](iam/concepts.md#gestion-des-propriétaires-sur-un-tenant)).
+
+Vous pouvez suivre l'utilisation d'un tenant via le __Rapport de consommation__ (voir [Consommation de ressource au sein d'un tenant](iam/concepts.md#consommation-de-ressource-au-sein-dun-tenant)).
+
+La journalisation des activités, qui fait également partie du module __Administration__, est détaillée ci-dessous.
 
 __Journalisation - Suivi des Activités__
 =====================================

--- a/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -16,6 +16,8 @@ import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_cr
 import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
 import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
 import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
+import shivaOrdersList from '@site/docs/console/images/shiva_orders_list.png'
+import shivaOrdersIaasCpoolEsx from '@site/docs/console/images/shiva_orders_iaas_cpool_esx.png'
 
 ## Voraussetzungen
 
@@ -194,16 +196,30 @@ Gemäß der SecNumCloud-Qualifikation ist der Zugriff auf die Console auf zuvor 
 - Adresse hinzufügen: Berechtigung `console_public_access_write`.
 - Das __Entfernen__ einer zugelassenen IP erfolgt über eine Support-Anfrage.
 
-### Die Produkte eines Tenants bestellen und verwalten
+### Die Seite Support
 
-Ressourcen und Produkte (Compute, Speicher, Netzwerk, Bastion, Colocation…) werden über das Modul __Bestellung__ bestellt (Berechtigung `order_read` für die Nachverfolgung, `order_write` für die Erstellung) und werden __einem bestimmten Tenant zugewiesen__: Sie werden nicht mit den anderen Tenants geteilt. Die Nachverfolgung der Bereitstellungen erfolgt in demselben Modul (das Tenant-Dashboard zeigt die laufenden Bestellungen an).
+Über __Administration > Support__ sehen Sie Ihre dem Tenant zugeordneten __Support-Vorgänge__ ein und verfolgen sie: Beratungsanfragen, kontobezogene Unterstützung, Vorfälle und Anfragen für professionelle Dienstleistungen. Die zugehörigen Berechtigungen sind `support_read` (eigene Vorgänge einsehen), `support_write` (einen Vorgang erstellen) und `support_management` (alle Vorgänge des Tenants einsehen). Das schrittweise Erstellen eines Vorgangs wird im Abschnitt „Zugang zum technischen Support" weiter oben beschrieben.
+
+### Die Produkte eines Tenants erstellen und aktualisieren
+
+Die Produkte und Ressourcen eines Tenants (Compute, Speicher, Netzwerk, Bastion, Colocation…) werden über das Modul __Bestellung__ verwaltet (Berechtigung `order_read` für die Nachverfolgung, `order_write` für die Erstellung). Jede bestellte Ressource wird __einem bestimmten Tenant zugewiesen__ und nicht mit den anderen geteilt.
+
+<img src={shivaOrdersList} />
+
+__Ein Produkt oder eine Ressource erstellen__: Wählen Sie im Modul __Bestellung__ den Ziel-Tenant und dann das zu aktivierende Produkt aus (Verfügbarkeitszone, Compute-Cluster, Speicher-Cluster, Netzwerk…). Die Bestellung wird validiert und dann bereitgestellt; ihr Fortschritt ist in der Bestellliste und im Tenant-Dashboard sichtbar.
+
+__Aktualisieren oder skalieren__: Das Hinzufügen von Kapazität zu einem bestehenden Produkt erfolgt ebenfalls über eine Bestellung — zum Beispiel das Hinzufügen eines Hypervisors oder von Arbeitsspeicher zu einem Compute-Cluster, eines Datastores zu einem Speicher-Cluster oder eines neuen Netzwerks.
+
+<img src={shivaOrdersIaasCpoolEsx} />
+
+Erinnerungen zum Lebenszyklus:
 
 - __Initialisierung__: Ein Tenant darf nicht leer sein; er startet mit mindestens einer Verfügbarkeitszone, einem Compute-Cluster, einem Speicherbereich und einem Netzwerk-VLAN.
 - __Weiterentwicklung__: Sie fügen Ressourcen durch neue Bestellungen hinzu oder entfernen sie, und Sie können die Architektur durch Hinzufügen oder Entfernen von Tenants weiterentwickeln.
 - __Tenant-übergreifende Netzwerke__: Um die Netzwerkkontinuität zwischen Tenants zu gewährleisten, können „cross tenant"-Netzwerke angefordert werden.
 - __Berechtigungen__: Ein Eigentümer des Tenants besitzt automatisch alle Berechtigungen der auf diesem Tenant aktivierten Produkte (siehe unten).
 
-Der detaillierte Bestellablauf wird in [Bestellungen](orders.md) beschrieben; die Definition und die Aktivierungsreferenzen eines Tenants finden Sie unter [Tenant](iam/concepts.md#tenant).
+Die Details zu jeder Bestellart (Verfügbarkeitszone, Cluster, Speicher, Netzwerke, Hinzufügen von Hypervisoren oder Arbeitsspeicher…) sind in [Bestellungen](orders.md) dokumentiert; die Definition und die Aktivierungsreferenzen eines Tenants finden Sie unter [Tenant](iam/concepts.md#tenant).
 
 ### Eigentümer und Lebenszyklus eines Tenants
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -159,6 +159,15 @@ Die Berechtigungen der Benutzer werden __pro Tenant__ definiert: Ein und dasselb
 Diese Seite beschreibt den Ablauf in der Console. Für die ausführliche Referenz — Definitionen, Lebenszyklus, Identitätsföderation und die vollständige Liste der Berechtigungen — siehe das Modul IAM: [Konzepte](iam/concepts.md) und [IAM-Schnellstart](iam/quickstart.md).
 :::
 
+### Das Modul Administration auf einen Blick
+
+Das Modul __Administration__ fasst vier Menüs zusammen:
+
+- __Support__: Sehen Sie Ihre Support-Vorgänge für den Tenant ein und verfolgen Sie sie (Berechtigungen `support_read`, `support_write`, `support_management`). Das Erstellen eines Vorgangs wird im Abschnitt „Zugang zum technischen Support" weiter oben beschrieben.
+- __Benutzer__: Laden Sie die Konten Ihrer Organisation ein und weisen Sie ihre Berechtigungen pro Tenant zu (Berechtigungen `iam_read`, `iam_write`). Nachstehend im Detail.
+- __Logs__: Protokoll der in der Console durchgeführten Lese- und Schreiboperationen zu Nachverfolgbarkeitszwecken (Berechtigung `activity_read`). Im Detail unter „Protokollierung" nachstehend.
+- __Zugriff__: Verwalten Sie die Whitelist der öffentlichen IP-Adressen, die auf die Console zugreifen dürfen (Berechtigungen `console_public_access_read`, `console_public_access_write`). Nachstehend im Detail.
+
 ### Den Arbeits-Tenant auswählen
 
 Der Tenant-Selektor befindet sich oben links in der Console. Er ermöglicht den Wechsel von einem Bereich zum anderen; qualifizierte Tenants zeigen das Abzeichen __SecNumCloud__ an.
@@ -184,6 +193,17 @@ Gemäß der SecNumCloud-Qualifikation ist der Zugriff auf die Console auf zuvor 
 - Liste einsehen: Berechtigung `console_public_access_read`.
 - Adresse hinzufügen: Berechtigung `console_public_access_write`.
 - Das __Entfernen__ einer zugelassenen IP erfolgt über eine Support-Anfrage.
+
+### Die Produkte eines Tenants bestellen und verwalten
+
+Ressourcen und Produkte (Compute, Speicher, Netzwerk, Bastion, Colocation…) werden über das Modul __Bestellung__ bestellt (Berechtigung `order_read` für die Nachverfolgung, `order_write` für die Erstellung) und werden __einem bestimmten Tenant zugewiesen__: Sie werden nicht mit den anderen Tenants geteilt. Die Nachverfolgung der Bereitstellungen erfolgt in demselben Modul (das Tenant-Dashboard zeigt die laufenden Bestellungen an).
+
+- __Initialisierung__: Ein Tenant darf nicht leer sein; er startet mit mindestens einer Verfügbarkeitszone, einem Compute-Cluster, einem Speicherbereich und einem Netzwerk-VLAN.
+- __Weiterentwicklung__: Sie fügen Ressourcen durch neue Bestellungen hinzu oder entfernen sie, und Sie können die Architektur durch Hinzufügen oder Entfernen von Tenants weiterentwickeln.
+- __Tenant-übergreifende Netzwerke__: Um die Netzwerkkontinuität zwischen Tenants zu gewährleisten, können „cross tenant"-Netzwerke angefordert werden.
+- __Berechtigungen__: Ein Eigentümer des Tenants besitzt automatisch alle Berechtigungen der auf diesem Tenant aktivierten Produkte (siehe unten).
+
+Der detaillierte Bestellablauf wird in [Bestellungen](orders.md) beschrieben; die Definition und die Aktivierungsreferenzen eines Tenants finden Sie unter [Tenant](iam/concepts.md#tenant).
 
 ### Eigentümer und Lebenszyklus eines Tenants
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -13,6 +13,9 @@ import shivaLogs from '@site/docs/console/images/shiva_logs.png'
 import shivaOnboard_009 from '@site/docs/console/images/shiva_onboard_009.png'
 import shivaOnboard_008 from '@site/docs/console/images/shiva_onboard_008.png'
 import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_criticities.png'
+import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
+import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
+import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
 
 ## Voraussetzungen
 
@@ -142,6 +145,53 @@ Nachfolgend eine Übersicht der verfügbaren Module. Die Konsole wird regelmäß
 </div>
 </div>
 Die Symbole __'NEW'__ bedeuten, dass das betreffende Produkt bereitgestellt wurde, aber noch nicht für das __SecNumCloud-Angebot__ zertifiziert ist, und __'BETA'__ bedeuten, dass das betreffende Produkt bereitgestellt und kürzlich für das __SecNumCloud-Angebot__ zertififiziert wurde.
+
+## Administration: Ihre Organisation und Ihre Tenants
+
+Das Modul __Administration__ (unten im grünen Menüband, links) bündelt die Verwaltung Ihrer __Organisation__ und Ihrer __Tenants__: Auswahl des Arbeitsbereichs, Verwaltung der Benutzer und ihrer Berechtigungen, Zugriffsbeschränkung per IP sowie Protokollierung.
+
+- Die __Organisation__ ist Ihre vertragliche Einheit: Sie enthält die Benutzerkonten, den Authentifizierungsmechanismus (lokales Verzeichnis oder Identitätsföderation) und föderiert alle Ihre Tenants.
+- Ein __Tenant__ ist eine abgeschottete Gruppierung von Ressourcen innerhalb der Organisation (Produktion, Vorproduktion, pro Anwendung, pro Kritikalität…). Die Ressourcen eines Tenants werden nicht mit den anderen geteilt.
+
+Die Berechtigungen der Benutzer werden __pro Tenant__ definiert: Ein und dasselbe Konto kann beispielsweise auf einem Tenant Ressourcen bestellen und auf einem anderen nur einsehen.
+
+:::info
+Diese Seite beschreibt den Ablauf in der Console. Für die ausführliche Referenz — Definitionen, Lebenszyklus, Identitätsföderation und die vollständige Liste der Berechtigungen — siehe das Modul IAM: [Konzepte](iam/concepts.md) und [IAM-Schnellstart](iam/quickstart.md).
+:::
+
+### Den Arbeits-Tenant auswählen
+
+Der Tenant-Selektor befindet sich oben links in der Console. Er ermöglicht den Wechsel von einem Bereich zum anderen; qualifizierte Tenants zeigen das Abzeichen __SecNumCloud__ an.
+
+<img src={shivaTenant} />
+
+Die Erstellung eines Tenants erfolgt über eine Serviceanfrage (siehe [Erstellung eines Tenants](iam/quickstart.md#creation-of-a-tenant)). Ein Tenant darf nicht leer sein: Er wird mit mindestens einer Verfügbarkeitszone, einem Compute-Cluster, einem Speicherbereich und einem Netzwerk-VLAN initialisiert.
+
+### Benutzer und ihre Berechtigungen verwalten
+
+Über __Administration > Benutzer__ laden Sie einen Benutzer per E-Mail ein und weisen ihm anschließend seine Berechtigungen __für jeden Tenant__ zu. Standardmäßig besitzt ein Konto keine Berechtigung; die Zuweisung erfordert die Berechtigung `iam_write`.
+
+<img src={shivaOnboard_005} />
+
+Die Berechtigungen sind __einzeln__ (sie überschneiden sich nicht) und __kumulativ__: Eine Aktion kann mehrere Berechtigungen erfordern (zum Beispiel `..._read` __und__ `..._write`). Das vollständige Verfahren und die [vollständige Liste der Berechtigungen](iam/concepts.md#berechtigungen) sind im Modul IAM dokumentiert.
+
+### Zugriff beschränken: zugelassene IPs (Whitelist IP)
+
+Gemäß der SecNumCloud-Qualifikation ist der Zugriff auf die Console auf zuvor deklarierte öffentliche IP-Adressen beschränkt. Über __Administration > Zugriff__ sehen Sie die zugelassenen IPs und Subnets ein und fügen sie hinzu.
+
+<img src={shivaIpAccessManagement_01} />
+
+- Liste einsehen: Berechtigung `console_public_access_read`.
+- Adresse hinzufügen: Berechtigung `console_public_access_write`.
+- Das __Entfernen__ einer zugelassenen IP erfolgt über eine Support-Anfrage.
+
+### Eigentümer und Lebenszyklus eines Tenants
+
+Jeder Tenant hat mindestens einen __Eigentümer__, der automatisch alle Berechtigungen der auf diesem Tenant aktivierten Produkte besitzt. Diese Berechtigungen sind nicht änderbar, und die Oberfläche warnt ab mehr als 3 Eigentümern, um das Prinzip der minimalen Rechtevergabe zu fördern. Das Entfernen eines Eigentümers erfolgt über eine Support-Anfrage (siehe [Verwaltung der Eigentümer auf einem Tenant](iam/concepts.md#verwaltung-der-eigentümer-auf-einem-tenant)).
+
+Sie können die Nutzung eines Tenants über den __Verbrauchsbericht__ verfolgen (siehe [Ressourcenverbrauch innerhalb eines Tenants](iam/concepts.md#ressourcenverbrauch-innerhalb-eines-tenants)).
+
+Die Protokollierung der Aktivitäten, die ebenfalls Teil des Moduls __Administration__ ist, wird nachstehend beschrieben.
 
 __Protokollierung - Aktivitätsverfolgung__
 =====================================

--- a/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -13,6 +13,9 @@ import shivaLogs from '@site/docs/console/images/shiva_logs.png'
 import shivaOnboard_009 from '@site/docs/console/images/shiva_onboard_009.png'
 import shivaOnboard_008 from '@site/docs/console/images/shiva_onboard_008.png'
 import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_criticities.png'
+import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
+import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
+import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
 
 ## Prerequisites
 
@@ -142,6 +145,53 @@ Below is a presentation of the available modules. New modules are regularly adde
 </div>
 </div>
 The __'NEW'__ pictograms indicate that the product in question has been provisioned but is not yet qualified under the __SecNumCloud offer__, and __'BETA'__ indicates that the product in question has been provisioned and has just been qualified under the __SecNumCloud offer__.
+
+## Administration: your organization and your tenants
+
+The __Administration__ module (at the bottom of the green banner, on the left) brings together the management of your __organization__ and your __tenants__: selecting the working scope, managing users and their permissions, restricting access by IP, and logging.
+
+- The __organization__ is your contractual entity: it holds the user accounts, the authentication mechanism (local directory or identity federation) and federates all of your tenants.
+- A __tenant__ is a partitioned grouping of resources within the organization (Production, Pre-production, per application, per criticality…). The resources of one tenant are not shared with the others.
+
+User permissions are defined __on a per-tenant basis__: the same account may, for example, order resources on one tenant and only view them on another.
+
+:::info
+This page describes the workflow within the Console. For the detailed reference — definitions, lifecycle, identity federation and the exhaustive list of permissions — refer to the IAM module: [Concepts](iam/concepts.md) and [IAM Quickstart](iam/quickstart.md).
+:::
+
+### Selecting the working tenant
+
+The tenant selector is located in the top left of the Console. It lets you switch from one scope to another; qualified tenants display the __SecNumCloud__ badge.
+
+<img src={shivaTenant} />
+
+Creating a tenant is done through a service request (see [Tenant Creation](iam/quickstart.md#tenant)). A tenant cannot be empty: it is initialized with at least one availability zone, one compute cluster, one storage space and one network VLAN.
+
+### Managing users and their permissions
+
+From __Administration > Users__, you invite a user by e-mail, then assign their permissions __for each tenant__. By default, an account has no permission; assigning them requires the `iam_write` permission.
+
+<img src={shivaOnboard_005} />
+
+Permissions are __unitary__ (they do not overlap) and __cumulative__: an action may require several permissions (for example `..._read` __and__ `..._write`). The full procedure and the [exhaustive list of permissions](iam/concepts.md#permissions) are documented in the IAM module.
+
+### Restricting access: authorized IPs (Whitelist IP)
+
+In accordance with the SecNumCloud qualification, access to the Console is limited to previously declared public IP addresses. From __Administration > Access__, you view and add the authorized IPs and subnets.
+
+<img src={shivaIpAccessManagement_01} />
+
+- Viewing the list: `console_public_access_read` permission.
+- Adding an address: `console_public_access_write` permission.
+- __Removing__ an authorized IP is done through a support request.
+
+### Owners and tenant lifecycle
+
+Each tenant has at least one __owner__, who automatically holds all the permissions of the products enabled on that tenant. These permissions cannot be modified, and the interface warns beyond 3 owners in order to encourage least privilege. Removing an owner goes through a support request (see [Managing owners on a tenant](iam/concepts.md#managing-owners-on-a-tenant)).
+
+You can track a tenant's usage via the __Consumption report__ (see [Resource consumption within a tenant](iam/concepts.md#resource-consumption-within-a-tenant)).
+
+Activity logging, which is also part of the __Administration__ module, is detailed below.
 
 __Logging - Activity Tracking__
 =====================================

--- a/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -159,6 +159,15 @@ User permissions are defined __on a per-tenant basis__: the same account may, fo
 This page describes the workflow within the Console. For the detailed reference — definitions, lifecycle, identity federation and the exhaustive list of permissions — refer to the IAM module: [Concepts](iam/concepts.md) and [IAM Quickstart](iam/quickstart.md).
 :::
 
+### The Administration module at a glance
+
+The __Administration__ module brings together four menus:
+
+- __Support__: view and track your support tickets for the tenant (`support_read`, `support_write`, `support_management` permissions). Creating a ticket is described in the "Technical Support Access" section above.
+- __Users__: invite the accounts of your organization and assign their permissions on a per-tenant basis (`iam_read`, `iam_write` permissions). Detailed below.
+- __Logs__: log of the read and write operations performed in the Console, for traceability purposes (`activity_read` permission). Detailed in "Logging" below.
+- __Access__: manage the whitelist of public IP addresses allowed to access the Console (`console_public_access_read`, `console_public_access_write` permissions). Detailed below.
+
 ### Selecting the working tenant
 
 The tenant selector is located in the top left of the Console. It lets you switch from one scope to another; qualified tenants display the __SecNumCloud__ badge.
@@ -184,6 +193,17 @@ In accordance with the SecNumCloud qualification, access to the Console is limit
 - Viewing the list: `console_public_access_read` permission.
 - Adding an address: `console_public_access_write` permission.
 - __Removing__ an authorized IP is done through a support request.
+
+### Ordering and managing a tenant's products
+
+Resources and products (compute, storage, network, bastion, colocation…) are ordered from the __Order__ module (`order_read` permission for tracking, `order_write` for creation) and are __assigned to a specific tenant__: they are not shared with the other tenants. Deployment tracking is done in this same module (the tenant dashboard shows the orders in progress).
+
+- __Initialization__: a tenant cannot be empty; it starts with at least one availability zone, one compute cluster, one storage space and one network VLAN.
+- __Evolution__: you add or remove resources by placing new orders, and you can evolve the architecture by adding or removing tenants.
+- __Cross-tenant networks__: to ensure network continuity between tenants, "cross tenant" networks can be requested.
+- __Permissions__: a tenant owner automatically holds all the permissions of the products enabled on that tenant (see below).
+
+The detailed ordering process is described in [Orders](orders.md); the definition and activation references of a tenant are given in [Tenant](iam/concepts.md#tenant).
 
 ### Owners and tenant lifecycle
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -16,6 +16,8 @@ import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_cr
 import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
 import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
 import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
+import shivaOrdersList from '@site/docs/console/images/shiva_orders_list.png'
+import shivaOrdersIaasCpoolEsx from '@site/docs/console/images/shiva_orders_iaas_cpool_esx.png'
 
 ## Prerequisites
 
@@ -194,16 +196,30 @@ In accordance with the SecNumCloud qualification, access to the Console is limit
 - Adding an address: `console_public_access_write` permission.
 - __Removing__ an authorized IP is done through a support request.
 
-### Ordering and managing a tenant's products
+### The Support page
 
-Resources and products (compute, storage, network, bastion, colocation…) are ordered from the __Order__ module (`order_read` permission for tracking, `order_write` for creation) and are __assigned to a specific tenant__: they are not shared with the other tenants. Deployment tracking is done in this same module (the tenant dashboard shows the orders in progress).
+From __Administration > Support__, you view and track your __support tickets__ attached to the tenant: advice requests, account-related assistance, incidents and professional service requests. The associated permissions are `support_read` (view your own tickets), `support_write` (create a ticket) and `support_management` (view all the tenant's tickets). The step-by-step creation of a ticket is described in the "Technical Support Access" section above.
+
+### Creating and updating a tenant's products
+
+A tenant's products and resources (compute, storage, network, bastion, colocation…) are managed from the __Order__ module (`order_read` permission for tracking, `order_write` for creation). Any ordered resource is __assigned to a specific tenant__ and is not shared with the others.
+
+<img src={shivaOrdersList} />
+
+__Creating a product or resource__: from the __Order__ module, select the target tenant then the product to activate (availability zone, compute cluster, storage cluster, network…). The order is validated then deployed; its progress is visible in the orders list and on the tenant dashboard.
+
+__Updating or scaling__: adding capacity to an existing product also goes through an order — for example adding a hypervisor or memory to a compute cluster, a datastore to a storage cluster, or a new network.
+
+<img src={shivaOrdersIaasCpoolEsx} />
+
+Lifecycle reminders:
 
 - __Initialization__: a tenant cannot be empty; it starts with at least one availability zone, one compute cluster, one storage space and one network VLAN.
 - __Evolution__: you add or remove resources by placing new orders, and you can evolve the architecture by adding or removing tenants.
 - __Cross-tenant networks__: to ensure network continuity between tenants, "cross tenant" networks can be requested.
 - __Permissions__: a tenant owner automatically holds all the permissions of the products enabled on that tenant (see below).
 
-The detailed ordering process is described in [Orders](orders.md); the definition and activation references of a tenant are given in [Tenant](iam/concepts.md#tenant).
+The details of each type of order (availability zone, clusters, storage, networks, adding hypervisors or memory…) are documented in [Orders](orders.md); the definition and activation references of a tenant are given in [Tenant](iam/concepts.md#tenant).
 
 ### Owners and tenant lifecycle
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -13,6 +13,9 @@ import shivaLogs from '@site/docs/console/images/shiva_logs.png'
 import shivaOnboard_009 from '@site/docs/console/images/shiva_onboard_009.png'
 import shivaOnboard_008 from '@site/docs/console/images/shiva_onboard_008.png'
 import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_criticities.png'
+import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
+import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
+import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
 
 ## Requisitos
 
@@ -142,6 +145,53 @@ A continuación se presenta una descripción de los diferentes módulos disponib
 </div>
 </div>
 Los pictogramas __'NEW'__ indican que el producto en cuestión ha sido aprovisionado pero aún no está cualificado para la __oferta SecNumCloud__, y __'BETA'__ indican que el producto en cuestión ha sido aprovisionado y acaba de ser cualificado para la __oferta SecNumCloud__.
+
+## Administración: su organización y sus tenants
+
+El módulo __Administración__ (en la parte inferior de la banda verde, a la izquierda) reúne la gestión de su __organización__ y de sus __tenants__: selección del ámbito de trabajo, gestión de los usuarios y de sus permisos, restricción de accesos por IP y registro de actividad.
+
+- La __organización__ es su entidad contractual: alberga las cuentas de usuario, el mecanismo de autenticación (directorio local o federación de identidades) y federa el conjunto de sus tenants.
+- Un __tenant__ es una agrupación de recursos aislada dentro de la organización (Producción, Preproducción, por aplicación, por criticidad…). Los recursos de un tenant no se comparten con los demás.
+
+Los permisos de los usuarios se definen __por cada tenant__: una misma cuenta puede, por ejemplo, pedir recursos en un tenant y solo consultarlos en otro.
+
+:::info
+Esta página describe el recorrido dentro de la Console. Para la referencia detallada — definiciones, ciclo de vida, federación de identidades y la lista exhaustiva de permisos — consulte el módulo IAM: [Conceptos](iam/concepts.md) y [Guía de inicio de IAM](iam/quickstart.md).
+:::
+
+### Seleccionar el tenant de trabajo
+
+El selector de tenant se encuentra en la parte superior izquierda de la Console. Permite cambiar de un ámbito a otro; los tenants cualificados muestran la insignia __SecNumCloud__.
+
+<img src={shivaTenant} />
+
+La creación de un tenant se realiza mediante una solicitud de servicio (véase [Creación de un tenant](iam/quickstart.md#creación-de-un-tenant)). Un tenant no puede estar vacío: se inicializa con al menos una zona de disponibilidad, un clúster de cómputo, un espacio de almacenamiento y una VLAN de red.
+
+### Gestionar los usuarios y sus permisos
+
+Desde __Administración > Usuarios__, invita a un usuario por correo electrónico y, a continuación, le asigna sus permisos __para cada tenant__. De forma predeterminada, una cuenta no posee ningún permiso; la asignación requiere el permiso `iam_write`.
+
+<img src={shivaOnboard_005} />
+
+Los permisos son __unitarios__ (no se solapan) y __acumulativos__: una acción puede exigir varios permisos (por ejemplo `..._read` __y__ `..._write`). El procedimiento completo y la [lista exhaustiva de permisos](iam/concepts.md#permisos) están documentados en el módulo IAM.
+
+### Restringir los accesos: IP autorizadas (Whitelist IP)
+
+De conformidad con la cualificación SecNumCloud, el acceso a la Console se limita a las direcciones IP públicas previamente declaradas. Desde __Administración > Acceso__, consulta y añade las IP y subnets autorizados.
+
+<img src={shivaIpAccessManagement_01} />
+
+- Consultar la lista: permiso `console_public_access_read`.
+- Añadir una dirección: permiso `console_public_access_write`.
+- La __eliminación__ de una IP autorizada se realiza mediante una solicitud de soporte.
+
+### Propietarios y ciclo de vida de un tenant
+
+Cada tenant tiene al menos un __propietario__, que dispone automáticamente de todos los permisos de los productos activados en ese tenant. Estos permisos no se pueden modificar, y la interfaz avisa a partir de 3 propietarios para fomentar el mínimo privilegio. La retirada de un propietario se realiza mediante una solicitud de soporte (véase [Gestión de propietarios en un tenant](iam/concepts.md#gestión-de-propietarios-en-un-tenant)).
+
+Puede seguir el uso de un tenant mediante el __Informe de consumo__ (véase [Consumo de recursos en un inquilino](iam/concepts.md#consumo-de-recursos-en-un-inquilino)).
+
+El registro de actividad, que también forma parte del módulo __Administración__, se detalla a continuación.
 
 __Registro - Seguimiento de Actividades__
 =====================================

--- a/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -16,6 +16,8 @@ import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_cr
 import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
 import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
 import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
+import shivaOrdersList from '@site/docs/console/images/shiva_orders_list.png'
+import shivaOrdersIaasCpoolEsx from '@site/docs/console/images/shiva_orders_iaas_cpool_esx.png'
 
 ## Requisitos
 
@@ -194,16 +196,30 @@ De conformidad con la cualificación SecNumCloud, el acceso a la Console se limi
 - Añadir una dirección: permiso `console_public_access_write`.
 - La __eliminación__ de una IP autorizada se realiza mediante una solicitud de soporte.
 
-### Pedir y gestionar los productos de un tenant
+### La página Soporte
 
-Los recursos y productos (cómputo, almacenamiento, red, bastión, colocation…) se piden desde el módulo __Pedido__ (permiso `order_read` para el seguimiento, `order_write` para la creación) y se __asignan a un tenant concreto__: no se comparten con los demás tenants. El seguimiento de los despliegues se realiza en este mismo módulo (el tablero del tenant muestra los pedidos en curso).
+Desde __Administración > Soporte__, consulta y sigue sus __expedientes de soporte__ asociados al tenant: solicitudes de asesoramiento, asistencia relacionada con la cuenta, incidentes y solicitudes de servicio profesional. Los permisos asociados son `support_read` (consultar sus propios expedientes), `support_write` (crear un expediente) y `support_management` (consultar todos los expedientes del tenant). La creación paso a paso de un expediente se describe en la sección «Acceso al soporte técnico» más arriba.
+
+### Crear y actualizar los productos de un tenant
+
+Los productos y recursos de un tenant (cómputo, almacenamiento, red, bastión, colocation…) se gestionan desde el módulo __Pedido__ (permiso `order_read` para el seguimiento, `order_write` para la creación). Todo recurso pedido se __asigna a un tenant concreto__ y no se comparte con los demás.
+
+<img src={shivaOrdersList} />
+
+__Crear un producto o recurso__: desde el módulo __Pedido__, seleccione el tenant de destino y luego el producto que desea activar (zona de disponibilidad, clúster de cómputo, clúster de almacenamiento, red…). El pedido se valida y luego se despliega; su avance es visible en la lista de pedidos y en el tablero del tenant.
+
+__Actualizar o escalar__: añadir capacidad a un producto existente también se realiza mediante un pedido — por ejemplo añadir un hipervisor o memoria a un clúster de cómputo, un datastore a un clúster de almacenamiento, o una nueva red.
+
+<img src={shivaOrdersIaasCpoolEsx} />
+
+Recordatorios de ciclo de vida:
 
 - __Inicialización__: un tenant no puede estar vacío; comienza con al menos una zona de disponibilidad, un clúster de cómputo, un espacio de almacenamiento y una VLAN de red.
 - __Evolución__: añade o retira recursos realizando nuevos pedidos, y puede hacer evolucionar la arquitectura añadiendo o eliminando tenants.
 - __Redes entre tenants__: para garantizar la continuidad de red entre tenants, se pueden solicitar redes «cross tenant».
 - __Permisos__: un propietario del tenant dispone automáticamente de todos los permisos de los productos activados en ese tenant (véase más abajo).
 
-El proceso de pedido detallado se describe en [Pedidos](orders.md); la definición y las referencias de activación de un tenant figuran en [Tenant](iam/concepts.md#tenant).
+El detalle de cada tipo de pedido (zona de disponibilidad, clústeres, almacenamiento, redes, adición de hipervisores o memoria…) está documentado en [Pedidos](orders.md); la definición y las referencias de activación de un tenant figuran en [Tenant](iam/concepts.md#tenant).
 
 ### Propietarios y ciclo de vida de un tenant
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -159,6 +159,15 @@ Los permisos de los usuarios se definen __por cada tenant__: una misma cuenta pu
 Esta página describe el recorrido dentro de la Console. Para la referencia detallada — definiciones, ciclo de vida, federación de identidades y la lista exhaustiva de permisos — consulte el módulo IAM: [Conceptos](iam/concepts.md) y [Guía de inicio de IAM](iam/quickstart.md).
 :::
 
+### El módulo Administración de un vistazo
+
+El módulo __Administración__ reúne cuatro menús:
+
+- __Soporte__: consulte y siga sus expedientes de soporte para el tenant (permisos `support_read`, `support_write`, `support_management`). La creación de un expediente se describe en la sección «Acceso al soporte técnico» más arriba.
+- __Usuarios__: invite a las cuentas de su organización y asigne sus permisos por cada tenant (permisos `iam_read`, `iam_write`). Detallado más abajo.
+- __Logs__: registro de las operaciones de lectura y escritura realizadas en la Console, con fines de trazabilidad (permiso `activity_read`). Detallado en «Registro» más abajo.
+- __Acceso__: gestione la lista blanca de direcciones IP públicas autorizadas a acceder a la Console (permisos `console_public_access_read`, `console_public_access_write`). Detallado más abajo.
+
 ### Seleccionar el tenant de trabajo
 
 El selector de tenant se encuentra en la parte superior izquierda de la Console. Permite cambiar de un ámbito a otro; los tenants cualificados muestran la insignia __SecNumCloud__.
@@ -184,6 +193,17 @@ De conformidad con la cualificación SecNumCloud, el acceso a la Console se limi
 - Consultar la lista: permiso `console_public_access_read`.
 - Añadir una dirección: permiso `console_public_access_write`.
 - La __eliminación__ de una IP autorizada se realiza mediante una solicitud de soporte.
+
+### Pedir y gestionar los productos de un tenant
+
+Los recursos y productos (cómputo, almacenamiento, red, bastión, colocation…) se piden desde el módulo __Pedido__ (permiso `order_read` para el seguimiento, `order_write` para la creación) y se __asignan a un tenant concreto__: no se comparten con los demás tenants. El seguimiento de los despliegues se realiza en este mismo módulo (el tablero del tenant muestra los pedidos en curso).
+
+- __Inicialización__: un tenant no puede estar vacío; comienza con al menos una zona de disponibilidad, un clúster de cómputo, un espacio de almacenamiento y una VLAN de red.
+- __Evolución__: añade o retira recursos realizando nuevos pedidos, y puede hacer evolucionar la arquitectura añadiendo o eliminando tenants.
+- __Redes entre tenants__: para garantizar la continuidad de red entre tenants, se pueden solicitar redes «cross tenant».
+- __Permisos__: un propietario del tenant dispone automáticamente de todos los permisos de los productos activados en ese tenant (véase más abajo).
+
+El proceso de pedido detallado se describe en [Pedidos](orders.md); la definición y las referencias de activación de un tenant figuran en [Tenant](iam/concepts.md#tenant).
 
 ### Propietarios y ciclo de vida de un tenant
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -159,6 +159,15 @@ I permessi degli utenti si definiscono __per ogni tenant__: uno stesso account p
 Questa pagina descrive il percorso all'interno della Console. Per il riferimento dettagliato — definizioni, ciclo di vita, federazione delle identità ed elenco esaustivo dei permessi — consulta il modulo IAM: [Concetti](iam/concepts.md) e [Guida introduttiva IAM](iam/quickstart.md).
 :::
 
+### Il modulo Amministrazione in breve
+
+Il modulo __Amministrazione__ riunisce quattro menu:
+
+- __Supporto__: consulta e monitora le tue pratiche di supporto per il tenant (permessi `support_read`, `support_write`, `support_management`). La creazione di una pratica è descritta nella sezione «Accesso al supporto tecnico» qui sopra.
+- __Utenti__: invita gli account della tua organizzazione e assegna i loro permessi per ogni tenant (permessi `iam_read`, `iam_write`). Descritto di seguito.
+- __Logs__: registro delle operazioni di lettura e scrittura eseguite nella Console, a fini di tracciabilità (permesso `activity_read`). Descritto in «Registrazione» di seguito.
+- __Accesso__: gestisci la whitelist degli indirizzi IP pubblici autorizzati ad accedere alla Console (permessi `console_public_access_read`, `console_public_access_write`). Descritto di seguito.
+
 ### Selezionare il tenant di lavoro
 
 Il selettore di tenant si trova in alto a sinistra nella Console. Consente di passare da un perimetro all'altro; i tenant qualificati mostrano il badge __SecNumCloud__.
@@ -184,6 +193,17 @@ In conformità con la qualificazione SecNumCloud, l'accesso alla Console è limi
 - Consultare l'elenco: permesso `console_public_access_read`.
 - Aggiungere un indirizzo: permesso `console_public_access_write`.
 - La __rimozione__ di un IP autorizzato avviene tramite una richiesta di supporto.
+
+### Ordinare e gestire i prodotti di un tenant
+
+Le risorse e i prodotti (calcolo, archiviazione, rete, bastion, colocation…) si ordinano dal modulo __Ordine__ (permesso `order_read` per il monitoraggio, `order_write` per la creazione) e sono __assegnati a un tenant preciso__: non sono condivisi con gli altri tenant. Il monitoraggio dei deployment avviene nello stesso modulo (il cruscotto del tenant mostra gli ordini in corso).
+
+- __Inizializzazione__: un tenant non può essere vuoto; parte con almeno una zona di disponibilità, un cluster di calcolo, uno spazio di archiviazione e una VLAN di rete.
+- __Evoluzione__: aggiungi o rimuovi risorse effettuando nuovi ordini e puoi far evolvere l'architettura aggiungendo o rimuovendo tenant.
+- __Reti cross-tenant__: per garantire la continuità di rete tra tenant, è possibile richiedere reti «cross tenant».
+- __Permessi__: un proprietario del tenant dispone automaticamente di tutti i permessi dei prodotti attivati su quel tenant (vedere di seguito).
+
+La procedura di ordine dettagliata è descritta in [Ordini](orders.md); la definizione e i riferimenti di attivazione di un tenant sono riportati in [Tenant](iam/concepts.md#tenant).
 
 ### Proprietari e ciclo di vita di un tenant
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -16,6 +16,8 @@ import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_cr
 import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
 import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
 import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
+import shivaOrdersList from '@site/docs/console/images/shiva_orders_list.png'
+import shivaOrdersIaasCpoolEsx from '@site/docs/console/images/shiva_orders_iaas_cpool_esx.png'
 
 ## Prerequisiti
 
@@ -194,16 +196,30 @@ In conformità con la qualificazione SecNumCloud, l'accesso alla Console è limi
 - Aggiungere un indirizzo: permesso `console_public_access_write`.
 - La __rimozione__ di un IP autorizzato avviene tramite una richiesta di supporto.
 
-### Ordinare e gestire i prodotti di un tenant
+### La pagina Supporto
 
-Le risorse e i prodotti (calcolo, archiviazione, rete, bastion, colocation…) si ordinano dal modulo __Ordine__ (permesso `order_read` per il monitoraggio, `order_write` per la creazione) e sono __assegnati a un tenant preciso__: non sono condivisi con gli altri tenant. Il monitoraggio dei deployment avviene nello stesso modulo (il cruscotto del tenant mostra gli ordini in corso).
+Da __Amministrazione > Supporto__, consulti e monitori le tue __pratiche di supporto__ associate al tenant: richieste di consulenza, assistenza relativa all'account, incidenti e richieste di servizio professionale. I permessi associati sono `support_read` (consultare le proprie pratiche), `support_write` (creare una pratica) e `support_management` (consultare tutte le pratiche del tenant). La creazione passo passo di una pratica è descritta nella sezione «Accesso al supporto tecnico» qui sopra.
+
+### Creare e aggiornare i prodotti di un tenant
+
+I prodotti e le risorse di un tenant (calcolo, archiviazione, rete, bastion, colocation…) si gestiscono dal modulo __Ordine__ (permesso `order_read` per il monitoraggio, `order_write` per la creazione). Ogni risorsa ordinata è __assegnata a un tenant preciso__ e non è condivisa con gli altri.
+
+<img src={shivaOrdersList} />
+
+__Creare un prodotto o una risorsa__: dal modulo __Ordine__, seleziona il tenant di destinazione e poi il prodotto da attivare (zona di disponibilità, cluster di calcolo, cluster di archiviazione, rete…). L'ordine viene convalidato e poi distribuito; il suo avanzamento è visibile nell'elenco degli ordini e nel cruscotto del tenant.
+
+__Aggiornare o scalare__: l'aggiunta di capacità a un prodotto esistente avviene anch'essa tramite un ordine — ad esempio aggiungere un hypervisor o memoria a un cluster di calcolo, un datastore a un cluster di archiviazione, o una nuova rete.
+
+<img src={shivaOrdersIaasCpoolEsx} />
+
+Promemoria sul ciclo di vita:
 
 - __Inizializzazione__: un tenant non può essere vuoto; parte con almeno una zona di disponibilità, un cluster di calcolo, uno spazio di archiviazione e una VLAN di rete.
 - __Evoluzione__: aggiungi o rimuovi risorse effettuando nuovi ordini e puoi far evolvere l'architettura aggiungendo o rimuovendo tenant.
 - __Reti cross-tenant__: per garantire la continuità di rete tra tenant, è possibile richiedere reti «cross tenant».
 - __Permessi__: un proprietario del tenant dispone automaticamente di tutti i permessi dei prodotti attivati su quel tenant (vedere di seguito).
 
-La procedura di ordine dettagliata è descritta in [Ordini](orders.md); la definizione e i riferimenti di attivazione di un tenant sono riportati in [Tenant](iam/concepts.md#tenant).
+Il dettaglio di ogni tipo di ordine (zona di disponibilità, cluster, archiviazione, reti, aggiunta di hypervisor o memoria…) è documentato in [Ordini](orders.md); la definizione e i riferimenti di attivazione di un tenant sono riportati in [Tenant](iam/concepts.md#tenant).
 
 ### Proprietari e ciclo di vita di un tenant
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/console/console_quickstart.md
@@ -13,6 +13,9 @@ import shivaLogs from '@site/docs/console/images/shiva_logs.png'
 import shivaOnboard_009 from '@site/docs/console/images/shiva_onboard_009.png'
 import shivaOnboard_008 from '@site/docs/console/images/shiva_onboard_008.png'
 import shivaSupportCriticities from '@site/docs/console/images/shiva_incident_criticities.png'
+import shivaTenant from '@site/docs/console/iam/images/shiva_tenant.png'
+import shivaOnboard_005 from '@site/docs/console/iam/images/shiva_onboard_005.png'
+import shivaIpAccessManagement_01 from '@site/docs/console/iam/images/shiva_ip_access_management_01.png'
 
 ## Prerequisiti
 
@@ -142,6 +145,53 @@ Di seguito è presentata una panoramica dei diversi moduli disponibili. Nuovi mo
 </div>
 </div>
 Le etichette __'NEW'__ indicano che il prodotto in questione è stato provisionato ma non è ancora qualificato __offerta SecNumCloud__, mentre __'BETA'__ indicano che il prodotto in questione è stato provisionato ed è appena stato qualificato __offerta SecNumCloud__.
+
+## Amministrazione: la tua organizzazione e i tuoi tenant
+
+Il modulo __Amministrazione__ (in basso nella banda verde, a sinistra) raccoglie la gestione della tua __organizzazione__ e dei tuoi __tenant__: selezione del perimetro di lavoro, gestione degli utenti e dei loro permessi, restrizione degli accessi tramite IP e registrazione delle attività.
+
+- L'__organizzazione__ è la tua entità contrattuale: contiene gli account utente, il meccanismo di autenticazione (directory locale o federazione delle identità) e federa l'insieme dei tuoi tenant.
+- Un __tenant__ è un raggruppamento di risorse isolato all'interno dell'organizzazione (Produzione, Preproduzione, per applicazione, per criticità…). Le risorse di un tenant non sono condivise con gli altri.
+
+I permessi degli utenti si definiscono __per ogni tenant__: uno stesso account può, ad esempio, ordinare risorse su un tenant e soltanto consultarle su un altro.
+
+:::info
+Questa pagina descrive il percorso all'interno della Console. Per il riferimento dettagliato — definizioni, ciclo di vita, federazione delle identità ed elenco esaustivo dei permessi — consulta il modulo IAM: [Concetti](iam/concepts.md) e [Guida introduttiva IAM](iam/quickstart.md).
+:::
+
+### Selezionare il tenant di lavoro
+
+Il selettore di tenant si trova in alto a sinistra nella Console. Consente di passare da un perimetro all'altro; i tenant qualificati mostrano il badge __SecNumCloud__.
+
+<img src={shivaTenant} />
+
+La creazione di un tenant avviene tramite una richiesta di servizio (vedere [Creazione di un tenant](iam/quickstart.md#creazione-di-un-tenant)). Un tenant non può essere vuoto: viene inizializzato con almeno una zona di disponibilità, un cluster di calcolo, uno spazio di archiviazione e una VLAN di rete.
+
+### Gestire gli utenti e i loro permessi
+
+Da __Amministrazione > Utenti__, inviti un utente tramite e-mail, quindi gli assegni i permessi __per ogni tenant__. Per impostazione predefinita, un account non possiede alcun permesso; l'assegnazione richiede il permesso `iam_write`.
+
+<img src={shivaOnboard_005} />
+
+I permessi sono __unitari__ (non si sovrappongono) e __cumulativi__: un'azione può richiedere più permessi (ad esempio `..._read` __e__ `..._write`). La procedura completa e l'[elenco esaustivo dei permessi](iam/concepts.md#permessi) sono documentati nel modulo IAM.
+
+### Limitare gli accessi: IP autorizzati (Whitelist IP)
+
+In conformità con la qualificazione SecNumCloud, l'accesso alla Console è limitato agli indirizzi IP pubblici dichiarati in precedenza. Da __Amministrazione > Accesso__, consulti e aggiungi gli IP e i subnet autorizzati.
+
+<img src={shivaIpAccessManagement_01} />
+
+- Consultare l'elenco: permesso `console_public_access_read`.
+- Aggiungere un indirizzo: permesso `console_public_access_write`.
+- La __rimozione__ di un IP autorizzato avviene tramite una richiesta di supporto.
+
+### Proprietari e ciclo di vita di un tenant
+
+Ogni tenant ha almeno un __proprietario__, che dispone automaticamente di tutti i permessi dei prodotti attivati su quel tenant. Questi permessi non sono modificabili e l'interfaccia avvisa oltre i 3 proprietari per incoraggiare il privilegio minimo. La rimozione di un proprietario avviene tramite una richiesta di supporto (vedere [Gestione dei proprietari su un tenant](iam/concepts.md#gestione-dei-proprietari-su-un-tenant)).
+
+Puoi monitorare l'utilizzo di un tenant tramite il __Rapporto di consumo__ (vedere [Consumo di risorse all'interno di un tenant](iam/concepts.md#consumo-di-risorse-allinterno-di-un-tenant)).
+
+La registrazione delle attività, anch'essa parte del modulo __Amministrazione__, è descritta di seguito.
 
 __Registrazione - Monitoraggio delle Attività__
 =====================================

--- a/scripts/translate_py/translation-meta.json
+++ b/scripts/translate_py/translation-meta.json
@@ -73,10 +73,10 @@
       "it": "841ad2248c399df04592fd931ae946f3640e3c21d04528a1cdf967d020abed4a"
     },
     "console/console_quickstart.md": {
-      "en": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
-      "de": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
-      "es": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
-      "it": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd"
+      "en": "0692716137d7fc510fbb449b6cfe0b908d8ba2adaf2df7492a34b3426bedca74",
+      "de": "0692716137d7fc510fbb449b6cfe0b908d8ba2adaf2df7492a34b3426bedca74",
+      "es": "0692716137d7fc510fbb449b6cfe0b908d8ba2adaf2df7492a34b3426bedca74",
+      "it": "0692716137d7fc510fbb449b6cfe0b908d8ba2adaf2df7492a34b3426bedca74"
     },
     "console/iam/concepts.md": {
       "en": "31d1de239eb5fd87b60c60caab8da4781db26fb73b626c21ded17a494841559c",

--- a/scripts/translate_py/translation-meta.json
+++ b/scripts/translate_py/translation-meta.json
@@ -73,10 +73,10 @@
       "it": "841ad2248c399df04592fd931ae946f3640e3c21d04528a1cdf967d020abed4a"
     },
     "console/console_quickstart.md": {
-      "en": "c71708ad3cfbc3f9ef816c9aa2f2cfe0e7b36c964f4bbd0cf368bd1b8b9c7ce5",
-      "de": "c71708ad3cfbc3f9ef816c9aa2f2cfe0e7b36c964f4bbd0cf368bd1b8b9c7ce5",
-      "es": "c71708ad3cfbc3f9ef816c9aa2f2cfe0e7b36c964f4bbd0cf368bd1b8b9c7ce5",
-      "it": "c71708ad3cfbc3f9ef816c9aa2f2cfe0e7b36c964f4bbd0cf368bd1b8b9c7ce5"
+      "en": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
+      "de": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
+      "es": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
+      "it": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301"
     },
     "console/iam/concepts.md": {
       "en": "31d1de239eb5fd87b60c60caab8da4781db26fb73b626c21ded17a494841559c",

--- a/scripts/translate_py/translation-meta.json
+++ b/scripts/translate_py/translation-meta.json
@@ -73,10 +73,10 @@
       "it": "841ad2248c399df04592fd931ae946f3640e3c21d04528a1cdf967d020abed4a"
     },
     "console/console_quickstart.md": {
-      "en": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
-      "de": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
-      "es": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301",
-      "it": "83d36d352ff5bf1d33a1ec6e445181c04e84a8975fc4bd7c199688fabbdef301"
+      "en": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
+      "de": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
+      "es": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd",
+      "it": "195bf1b55373ee45c277bddecd1683691b834f67012fa65d49ad2f1cb42338cd"
     },
     "console/iam/concepts.md": {
       "en": "31d1de239eb5fd87b60c60caab8da4781db26fb73b626c21ded17a494841559c",


### PR DESCRIPTION
## Objectif

Documenter la **vue organisation** et la **gestion des tenants** dans le quickstart de la Console (`docs/console/console_quickstart.md`), demandé dans #319.

## Contenu (page par page)

Section « Administration : votre organisation et vos tenants » — une page = titre + description + capture :

- **Le module Administration en un coup d'œil** — les 4 menus (Support, Utilisateurs, Logs, Accès) avec leurs permissions ;
- **Sélectionner le tenant de travail** ;
- **Gérer les utilisateurs et leurs permissions** (par tenant) ;
- **Restreindre les accès : IP autorisées** (Whitelist IP) ;
- **La page Support** ;
- **Créer et mettre à jour les produits d'un tenant** — module Commande, création + mise à jour, illustré ;
- **Propriétaires et cycle de vie d'un tenant**.

Approche **parcours guidé + liens** : renvois vers `iam/concepts.md`, `iam/quickstart.md` et `orders.md` pour la référence exhaustive (pas de duplication).

## Traductions i18n (en / de / es / it)

- Section traduite dans les 4 langues, avec les **ancres de liens adaptées à chaque langue**.
- `scripts/translate_py/translation-meta.json` : hash source de `console/console_quickstart.md` ré-épinglé pour les 4 langues → le script de traduction considère le fichier à jour et ne réécrase pas ces traductions. L'état des autres fichiers est inchangé.

## Validation

- `yarn build` **OK** (exit 0, tous les locales). Aucun lien/ancre cassé introduit par cette page (les avertissements d'ancres du build concernent des pages préexistantes).

## Reste à faire

- [ ] Capture de la page **Support** (non capturable côté agent — filtre serveur sur le domaine dev `shiva.dev.ctlabs.me`).
- [ ] Captures **fraîches v4.26.2** (certaines captures réutilisées datent de versions antérieures).

Refs #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
