### PR TITLE
fix(repo): supprime les marqueurs de conflit commités sur dev (débloque #301)

### DIFF
--- a/memory-bank/swagger.yaml
+++ b/memory-bank/swagger.yaml
@@ -18,15 +18,6 @@ info:
 servers:
   - url: https://api.ai.cloud-temple.com
     description: API de production
->>>>>>> 43e454e868da40722a5f801fca9b55d0b02d39c2
-  - url: https://api.ai.cloud-temple.com
-    description: Alias DNS pour LB01 (Prod API)
-  - url: http://preprod.api.ai.cloud-temple.com
-    description: Alias DNS pour LB02 (Préprod API)
-=======
-  - url: https://api.ai.cloud-temple.com
-    description: API de production
->>>>>>> 43e454e868da40722a5f801fca9b55d0b02d39c2
 
 tags:
   - name: Chat

--- a/tests/llmaas/README.md
+++ b/tests/llmaas/README.md
@@ -60,24 +60,6 @@ cp .env.example .env
 ```
 
 Le fichier `.env` local ne doit jamais être commité. Les tests d'intégration réels nécessitent une clé fournie par l'environnement.
->>>>>>> 43e454e868da40722a5f801fca9b55d0b02d39c2
-### Token par Défaut
-Si non configuré, utilise `test-token-for-docs` (pour tests d'erreurs uniquement).
-
-### Fichier local optionnel
-```bash
-cp .env.example .env
-```
-
-Le fichier `.env` local ne doit jamais être commité. Les tests d'intégration réels nécessitent une clé fournie par l'environnement.
-=======
-### Fichier local optionnel
-```bash
-cp .env.example .env
-```
-
-Le fichier `.env` local ne doit jamais être commité. Les tests d'intégration réels nécessitent une clé fournie par l'environnement.
->>>>>>> 43e454e868da40722a5f801fca9b55d0b02d39c2
 
 ## 📦 Dépendances
 


### PR DESCRIPTION
## Problème

Le merge `ef9e0bb8 "Merge origin/dev"` a commité une résolution de conflit incomplète : des marqueurs de conflit sont restés dans deux fichiers de `dev`.

| Fichier | Impact sur `dev` |
|---|---|
| `memory-bank/swagger.yaml` | Fichier **YAML invalide**. Réintroduit l'entrée `http://preprod.api.ai.cloud-temple.com` (« Alias DNS pour LB02 (Préprod API) ») retirée par le correctif `43e454e8`. Le dépôt étant public, cet endpoint interne était exposé. |
| `tests/llmaas/README.md` | Structure Markdown cassée. Retour de la section « Token par Défaut » supprimée par ce même correctif. |

C'est également la **cause unique** des deux conflits de la PR #301 (`main` → `dev`).

## Correctif

Les deux fichiers sont réalignés sur la version de `main`, qui porte la résolution correcte de `43e454e8`.

Changement **purement soustractif** : 27 suppressions, 0 ajout. Aucun contenu légitime n'est perdu — le contenu de `dev` était exactement celui de `main` auquel s'ajoutaient les blocs périmés dupliqués et les marqueurs.

## Vérifications effectuées

- [x] Aucun marqueur de conflit restant dans les deux fichiers.
- [x] `memory-bank/swagger.yaml` reparsé avec succès ; `servers` ne contient plus que `https://api.ai.cloud-temple.com` (API de production).
- [x] Section « Token par Défaut » absente de `tests/llmaas/README.md`.
- [x] Les deux fichiers sont désormais identiques à leur version sur `main`.
- [x] Fusion de `main` simulée après ce correctif : **0 conflit**. Le reliquat de la PR #301 se réduit à `static/mail/console_organisation_menu.png`.
- [x] `.gitignore` durci et `tests/llmaas/.env.example` sont déjà présents sur `dev` : rien à reprendre de ce côté.

## Suite

Une fois cette PR fusionnée, la PR #301 devient fusionnable sans conflit.

> ⚠️ Ne pas utiliser le bouton « Resolve conflicts » de GitHub sur la PR #301 : sa branche source étant `main`, GitHub fusionnerait `dev` dans `main` et ferait descendre le contenu non publié de `dev` dans la branche de production.

## Point de suivi (hors périmètre)

La valeur `test-token-for-docs` reste codée en dur comme repli dans 7 fichiers de `tests/llmaas/` sur `dev` **et** sur `main`. C'est un placeholder et non un credential réel, mais il pourrait être remplacé par un échec explicite si `LLMAAS_API_KEY` est absente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
