### PR TITLE
docs(databases): retire le badge Beta de MariaDB et PostgreSQL Managé

### DIFF
--- a/docs/databases_overview.md
+++ b/docs/databases_overview.md
@@ -9,12 +9,12 @@ Les bases de données managées de Cloud Temple vous déchargent de la gestion o
 
 <div class="card-grid">
   <div class="card">
-    <h3>MariaDB Managé <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>MariaDB Managé</h3>
     <p>Moteur MariaDB on Kubernetes avec sauvegardes automatiques, haute disponibilité multi-AZ.</p>
     <a href="./managed_mariadb" class="card-link">Découvrir MariaDB Managé →</a>
   </div>
   <div class="card">
-    <h3>PostgreSQL Managé <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>PostgreSQL Managé</h3>
     <p>Moteur PostgreSQL on Kubernetes : StandAlone, Distributed, ou Entreprise.</p>
     <a href="./managed_postgresql" class="card-link">Découvrir PostgreSQL Managé →</a>
   </div>

--- a/i18n/de/docusaurus-plugin-content-docs/current/databases_overview.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/databases_overview.md
@@ -9,12 +9,12 @@ Die verwalteten Datenbanken von Cloud Temple entlasten Sie von der operativen Ve
 
 <div class="card-grid">
   <div class="card">
-    <h3>Verwaltete MariaDB <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>Verwaltete MariaDB</h3>
     <p>MariaDB-Engine auf Kubernetes mit automatischen Backups und Multi-AZ-High-Availability.</p>
     <a href="./managed_mariadb" class="card-link">Verwaltete MariaDB entdecken →</a>
   </div>
   <div class="card">
-    <h3>Verwaltete PostgreSQL <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>Verwaltete PostgreSQL</h3>
     <p>PostgreSQL-Engine auf Kubernetes: Standalone, Distributed oder Enterprise.</p>
     <a href="./managed_postgresql" class="card-link">Verwaltete PostgreSQL entdecken →</a>
   </div>

--- a/i18n/en/docusaurus-plugin-content-docs/current/databases_overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/databases_overview.md
@@ -9,12 +9,12 @@ Cloud Temple's managed databases relieve you of operational management (backups,
 
 <div class="card-grid">
   <div class="card">
-    <h3>Managed MariaDB <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>Managed MariaDB</h3>
     <p>MariaDB engine on Kubernetes with automatic backups, multi-AZ high availability.</p>
     <a href="./managed_mariadb" class="card-link">Discover Managed MariaDB →</a>
   </div>
   <div class="card">
-    <h3>Managed PostgreSQL <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>Managed PostgreSQL</h3>
     <p>PostgreSQL engine on Kubernetes: StandAlone, Distributed, or Enterprise.</p>
     <a href="./managed_postgresql" class="card-link">Discover Managed PostgreSQL →</a>
   </div>

--- a/i18n/es/docusaurus-plugin-content-docs/current/databases_overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/databases_overview.md
@@ -9,12 +9,12 @@ Las bases de datos gestionadas de Cloud Temple le liberan de la gestión operati
 
 <div class="card-grid">
   <div class="card">
-    <h3>MariaDB Gestionado <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>MariaDB Gestionado</h3>
     <p>Motor MariaDB en Kubernetes con copias de seguridad automáticas y alta disponibilidad multi-AZ.</p>
     <a href="./managed_mariadb" class="card-link">Descubrir MariaDB Gestionado →</a>
   </div>
   <div class="card">
-    <h3>PostgreSQL Gestionado <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>PostgreSQL Gestionado</h3>
     <p>Motor PostgreSQL en Kubernetes: StandAlone, Distributed o Entreprise.</p>
     <a href="./managed_postgresql" class="card-link">Descubrir PostgreSQL Gestionado →</a>
   </div>

--- a/i18n/it/docusaurus-plugin-content-docs/current/databases_overview.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/databases_overview.md
@@ -9,12 +9,12 @@ I database gestiti di Cloud Temple ti sollevano dalla gestione operativa (backup
 
 <div class="card-grid">
   <div class="card">
-    <h3>MariaDB Gestito <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>MariaDB Gestito</h3>
     <p>Motore MariaDB su Kubernetes con backup automatici, alta disponibilità multi-AZ.</p>
     <a href="./managed_mariadb" class="card-link">Scopri MariaDB Gestito →</a>
   </div>
   <div class="card">
-    <h3>PostgreSQL Gestito <span class="title-beta-badge">(Beta)</span></h3>
+    <h3>PostgreSQL Gestito</h3>
     <p>Motore PostgreSQL su Kubernetes: StandAlone, Distributed o Enterprise.</p>
     <a href="./managed_postgresql" class="card-link">Scopri PostgreSQL Gestito →</a>
   </div>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -530,7 +530,6 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'MariaDB Managé',
-          className: 'sidebar-beta',
           link: { type: 'doc', id: 'managed_mariadb/managed_mariadb' },
           items: [
             'managed_mariadb/managed_mariadb',
@@ -541,7 +540,6 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'PostgreSQL Managé',
-          className: 'sidebar-beta',
           link: { type: 'doc', id: 'managed_postgresql/managed_postgresql' },
           items: [
             'managed_postgresql/managed_postgresql',


### PR DESCRIPTION
Closes #334

## Problème

**MariaDB Managé** et **PostgreSQL Managé** portaient **deux libellés de maturité contradictoires** :
badge **Beta** (bleu) dans le sidebar et sur les cartes de la page `Databases`, badge **Preview** (orange)
sur le titre H1 des pages produit.

## Changement

On ne garde que le badge **Preview** des pages produit. Suppression de toute mention *Beta* sur ces deux produits :

| Fichier | Suppression |
|---|---|
| `sidebars.ts` | `className: 'sidebar-beta'` sur les 2 catégories (× 2) |
| `docs/databases_overview.md` | `<span class="title-beta-badge">(Beta)</span>` sur les 2 cartes (× 2) |
| `i18n/{en,de,es,it}/…/databases_overview.md` | idem (× 8) |

Le `className` du sidebar étant défini une seule fois dans `sidebars.ts` (partagé par les 5 locales),
le badge disparaît d'un coup en `fr`, `en`, `es`, `it` et `de`.

## Choix assumés (à challenger en review)

1. **Les classes CSS `.sidebar-beta` et `.title-beta-badge` sont conservées** dans `src/css/custom.css`,
   bien qu'elles deviennent inutilisées. Elles forment une paire symétrique avec `.sidebar-preview` /
   `.title-preview-badge` et embarquent une subtilité non triviale (`::before` sur
   `.menu__list-item-collapsible` plutôt que `::after` sur le lien, pour éviter que la flèche de
   collapse Docusaurus ne fasse pivoter le badge à 90°). Les supprimer obligerait à re-dériver ce
   contournement au prochain produit en beta. Dites-le si vous préférez un nettoyage complet.
2. **Aucun badge de remplacement dans le sidebar.** Les deux produits deviennent les seuls non-GA sans
   marqueur de maturité dans le sidebar (VM Instances et VPC portent `sidebar-preview`). C'est un choix
   délibéré : le badge Preview du H1 des pages produit reste la source unique de vérité.

## Vérification

- `yarn build` local : OK (voir statut CI ci-dessous, le job `build-branch` rejoue le build).
- Aucun autre fichier touché — diff strictement soustractif (12 suppressions, 0 ajout).
