### PR TITLE
docs(changelog): trace l'harmonisation du libellé de maturité des bases managées

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Suivi des Changements
 
+### 20 Août 2026 : Harmonisation du libellé de maturité des bases de données managées
+
+- **Navigation — Databases** : Suppression du badge **Beta** sur les entrées **MariaDB Managé** et **PostgreSQL Managé** du menu latéral et sur les cartes de la page Databases. Les deux services affichaient simultanément deux libellés de maturité contradictoires : *Beta* dans la navigation, *Preview* sur le titre de leurs pages produit. Seul le badge **Preview** est conservé, comme source unique de vérité sur le niveau de maturité de ces services. Traductions disponibles EN/DE/ES/IT.
+
 ### 15 Juillet 2026 : Précision sur le chiffrement Object Storage
 
 - **Object Storage (Sécurité)** : La section sur le chiffrement des données au repos (D@RE) précise désormais que le service utilise un chiffrement AES 256 bits certifié FIPS 140-3, via la bibliothèque logicielle RSA BSAFE Crypto-J en version 7.x.

--- a/i18n/de/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Änderungsverlauf
 
+### 20 August 2026 : Harmonisierung der Reifegrad-Kennzeichnung für verwaltete Datenbanken
+
+- **Navigation — Databases** : Entfernung des **Beta**-Badges bei den Einträgen **Verwaltete MariaDB** und **Verwaltete PostgreSQL** in der Seitennavigation sowie auf den Karten der Databases-Seite. Beide Dienste zeigten gleichzeitig zwei widersprüchliche Reifegrad-Kennzeichnungen: *Beta* in der Navigation und *Preview* im Titel ihrer Produktseiten. Nur das **Preview**-Badge bleibt erhalten und dient als einzige verbindliche Angabe zum Reifegrad dieser Dienste. Übersetzungen verfügbar: EN/DE/ES/IT.
+
 ### 26 Mai 2026 : Verbesserung des Übersetzungs-Workflows
 
 - **Übersetzung (Tooling)** : Hinzufügen der Optionen `--token`, `--url` und `--model` zum Python-Skript `scripts/translate_py/translate.py`. Das API-Token kann nun direkt über die Befehlszeile angegeben werden, ohne eine `.env`-Datei neu erstellen zu müssen. CLI-Optionen haben Vorrang vor Umgebungsvariablen.

--- a/i18n/en/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Change Tracking
 
+### August 20, 2026: Maturity label harmonization for managed databases
+
+- **Navigation — Databases** : Removed the **Beta** badge from the **Managed MariaDB** and **Managed PostgreSQL** sidebar entries and from the cards on the Databases page. Both services were displaying two contradictory maturity labels at once: *Beta* in the navigation, *Preview* on their product page titles. Only the **Preview** badge is kept, as the single source of truth for the maturity level of these services. Translations available in EN/DE/ES/IT.
+
 ### May 26, 2026: Translation Workflow Enhancement
 
 - **Translation (tooling)** : Added `--token`, `--url`, and `--model` options to the Python script `scripts/translate_py/translate.py`. The API token can now be provided directly via the command line, without recreating a `.env` file. CLI options take precedence over environment variables.

--- a/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Seguimiento de Cambios
 
+### 20 de agosto de 2026: Armonización de la etiqueta de madurez de las bases de datos gestionadas
+
+- **Navegación — Databases** : Eliminación de la insignia **Beta** en las entradas **MariaDB Gestionado** y **PostgreSQL Gestionado** del menú lateral y en las tarjetas de la página Databases. Ambos servicios mostraban simultáneamente dos etiquetas de madurez contradictorias: *Beta* en la navegación y *Preview* en el título de sus páginas de producto. Solo se conserva la insignia **Preview**, como fuente única de verdad sobre el nivel de madurez de estos servicios. Traducciones disponibles EN/DE/ES/IT.
+
 ### 26 de mayo de 2026: Mejora del flujo de trabajo de traducción
 
 - **Traducción (herramientas)** : Adición de las opciones `--token`, `--url` y `--model` al script de Python `scripts/translate_py/translate.py`. El token de API ahora puede proporcionarse directamente desde la línea de comandos, sin necesidad de recrear el archivo `.env`. Las opciones de CLI tienen prioridad sobre las variables de entorno.

--- a/i18n/it/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/changelog.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Tracciamento delle Modifiche
 
+### 20 Agosto 2026 : Armonizzazione dell'etichetta di maturità dei database gestiti
+
+- **Navigazione — Databases** : Rimozione del badge **Beta** dalle voci **MariaDB Gestito** e **PostgreSQL Gestito** del menu laterale e dalle schede della pagina Databases. Entrambi i servizi mostravano contemporaneamente due etichette di maturità contraddittorie: *Beta* nella navigazione e *Preview* nel titolo delle rispettive pagine prodotto. Viene mantenuto solo il badge **Preview**, come unica fonte di verità sul livello di maturità di questi servizi. Traduzioni disponibili EN/DE/ES/IT.
+
 ### 26 Maggio 2026 : Miglioramento del workflow di traduzione
 
 - **Traduzione (strumentazione)** : Aggiunta delle opzioni `--token`, `--url` e `--model` allo script Python `scripts/translate_py/translate.py`. Il token API può ora essere fornito direttamente da riga di comando, senza dover ricreare il file `.env`. Le opzioni CLI hanno la precedenza sulle variabili d'ambiente.


### PR DESCRIPTION
Complète #334 / #335 : la suppression du badge Beta n'avait pas été tracée dans le suivi des changements.

## Changement

Ajout d'une entrée **20 août 2026** en tête de `changelog.md`, dans les **5 langues** (fr, en, de, es, it), avec les noms produits localisés de chaque locale (*MariaDB Managé* / *Managed MariaDB* / *Verwaltete MariaDB* / *MariaDB Gestionado* / *MariaDB Gestito*).

## Formulation : harmonisation, pas sortie de beta

L'entrée décrit **une harmonisation de libellé**, pas une montée en maturité. Écrire « ces services ne sont plus en beta » serait faux : ils affichent toujours le badge **Preview** sur leur page produit. Ce qui a été corrigé, c'est la coexistence de deux libellés contradictoires (*Beta* en navigation vs *Preview* sur les pages).

## Choix : `changelog.md` et non `changelog_produits.md`

`changelog_produits.md` est versionné par release plateforme (dernière entrée `v4.38.0 — 2026-04-20`) et liste les évolutions **fonctionnelles** de la plateforme. Ici rien n'a changé côté produit : c'est un correctif d'affichage documentaire, donc `changelog.md` (« Suivi des Changements »), qui trace déjà ce type de changement de navigation. Dites-le si vous voulez aussi une entrée produit.

## Vérification

- `yarn build` local : **exit 0**, aucune nouvelle page en warning SSG par rapport au build précédent.
- Entrée rendue et vérifiée dans les 5 `changelog.html` générés (fr/en/es/it/de).
- ⚠️ Le job CI `build-branch` échouera : le tag Docker `docs:${BRANCH_NAME}` est invalide dès que la branche contient un `/`. Bug pré-existant du workflow, indépendant de cette PR — `Build Documentation` passe.