### PR TITLE
fix(i18n): traduit les libellés de menu qui s'affichaient en français

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -3,84 +3,228 @@
     "message": "Nächste",
     "description": "The label for version current"
   },
-  "sidebar.docSidebar.category.AdditionalContent": {
+  "sidebar.docSidebar.category.Console": {
+    "message": "Console",
+    "description": "The label for category 'Console' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Contenu additionnel": {
     "message": "Zusätzlicher Inhalt",
-    "description": "Libellé pour la catégorie Contenu additionnel dans la barre latérale docSidebar"
+    "description": "The label for category 'Contenu additionnel' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Billing": {
+    "message": "Billing",
+    "description": "The label for category 'Billing' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Security & Identity": {
+    "message": "Security & Identity",
+    "description": "The label for category 'Security & Identity' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IAM": {
     "message": "IAM",
-    "description": "The label for category IAM in sidebar docSidebar"
+    "description": "The label for category 'IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Tutoriels IAM": {
+    "message": "IAM-Tutorials",
+    "description": "The label for category 'Tutoriels IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Sécurité": {
+    "message": "Sicherheit",
+    "description": "The label for category 'Sécurité' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.AI": {
+    "message": "AI",
+    "description": "The label for category 'AI' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.llmaas_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Bare Metal": {
     "message": "Bare Metal",
-    "description": "The label for category Bare Metal in sidebar docSidebar"
+    "description": "The label for category 'Bare Metal' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Bastion": {
-    "message": "Bastion",
-    "description": "The label for category Bastion in sidebar docSidebar"
+  "sidebar.docSidebar.category.Compute": {
+    "message": "Compute",
+    "description": "The label for category 'Compute' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Housing": {
-    "message": "Unterkunft",
-    "description": "The label for category Housing in sidebar docSidebar"
+  "sidebar.docSidebar.category.VM Instances": {
+    "message": "VM Instances",
+    "description": "The label for category 'VM Instances' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vm_instances_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IaaS OpenSource": {
     "message": "IaaS OpenSource",
-    "description": "The label for category IaaS OpenSource in sidebar docSidebar"
+    "description": "The label for category 'IaaS OpenSource' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.IaaS VMware": {
-    "message": "IaaS VMware",
-    "description": "The label for category IaaS VMware in sidebar docSidebar"
-  },
-  "sidebar.docSidebar.category.Tutorials": {
-    "message": "Anleitungen",
-    "description": "The label for category Tutorials in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_opensource_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.High Availability": {
     "message": "Hochverfügbarkeit",
-    "description": "The label for category High Availability in sidebar docSidebar"
+    "description": "The label for category 'High Availability' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Backup": {
-    "message": "Backup",
-    "description": "The label for category Backup in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_opensource_backup": {
+    "message": "Sicherung",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.PaaS OpenShift": {
-    "message": "PaaS OpenShift",
-    "description": "The label for category PaaS OpenShift in sidebar docSidebar"
+  "sidebar.docSidebar.category.IaaS VMware": {
+    "message": "IaaS VMware",
+    "description": "The label for category 'IaaS VMware' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Security": {
-    "message": "Sicherheit",
-    "description": "The label for category Security in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_vmware_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.iaas_vmware_backup": {
+    "message": "Sicherung",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Network": {
     "message": "Netzwerk",
-    "description": "The label for category Network in sidebar docSidebar"
+    "description": "The label for category 'Network' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Privates Network": {
+  "sidebar.docSidebar.category.VPC": {
+    "message": "VPC",
+    "description": "The label for category 'VPC' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vpc_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Private Network": {
     "message": "Private Netzwerke",
-    "description": "The label for category Privates Network in sidebar docSidebar"
+    "description": "The label for category 'Private Network' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Internet": {
     "message": "Internet",
-    "description": "The label for category Internet in sidebar docSidebar"
+    "description": "The label for category 'Internet' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone": {
+    "message": "Private Backbone",
+    "description": "The label for category 'Private Backbone' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Storage": {
     "message": "Speicher",
-    "description": "The label for category Storage in sidebar docSidebar"
+    "description": "The label for category 'Storage' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Object Storage": {
     "message": "Objektspeicher",
-    "description": "The label for category Object Storage in sidebar docSidebar"
+    "description": "The label for category 'Object Storage' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Contractual documents": {
-    "message": "Vertragsdokumente",
-    "description": "The label for category Contractual documents in sidebar docSidebar"
+  "sidebar.docSidebar.category.oss_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.RACI": {
-    "message": "RACI",
-    "description": "The label for the doc item RACI in sidebar docSidebar, linking to the doc governance/paas/raci"
+  "sidebar.docSidebar.category.Monitoring": {
+    "message": "Monitoring",
+    "description": "The label for category 'Monitoring' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.Service Agreement": {
-    "message": "Dienstleistungsvereinbarung",
-    "description": "The label for the doc item Service Agreement in sidebar docSidebar, linking to the doc governance/paas/service_agreement_paas"
+  "sidebar.docSidebar.category.Security": {
+    "message": "Sicherheit",
+    "description": "The label for category 'Security' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Bastion": {
+    "message": "Bastion",
+    "description": "The label for category 'Bastion' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Housing (Colocation)": {
+    "message": "Housing (Colocation)",
+    "description": "The label for category 'Housing (Colocation)' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Marketplace": {
+    "message": "Marketplace",
+    "description": "The label for category 'Marketplace' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.marketplace_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.containers_products": {
+    "message": "Containers",
+    "description": "The label for category 'Containers' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PaaS OpenShift": {
+    "message": "PaaS OpenShift",
+    "description": "The label for category 'PaaS OpenShift' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.paas_openshift_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Developer Tools": {
+    "message": "Developer Tools",
+    "description": "The label for category 'Developer Tools' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Terraform Provider": {
+    "message": "Terraform Provider",
+    "description": "The label for category 'Terraform Provider' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Kubernetes": {
+    "message": "Kubernetes",
+    "description": "The label for category 'Kubernetes' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.managed_kubernetes_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Databases": {
+    "message": "Databases",
+    "description": "The label for category 'Databases' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.MariaDB Managé": {
+    "message": "Verwaltete MariaDB",
+    "description": "The label for category 'MariaDB Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PostgreSQL Managé": {
+    "message": "Verwaltete PostgreSQL",
+    "description": "The label for category 'PostgreSQL Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.link.Tarifs publics": {
+    "message": "Öffentliche Preise",
+    "description": "The label for link 'Tarifs publics' in sidebar 'docSidebar', linking to 'https://www.cloud-temple.com/nos-tarifs-publics/'"
+  },
+  "sidebar.docSidebar.link.GitHub Cloud Temple": {
+    "message": "GitHub Cloud Temple",
+    "description": "The label for link 'GitHub Cloud Temple' in sidebar 'docSidebar', linking to 'https://github.com/cloud-temple'"
+  },
+  "sidebar.docSidebar.link.Roadmap produit": {
+    "message": "Produkt-Roadmap",
+    "description": "The label for link 'Roadmap produit' in sidebar 'docSidebar', linking to 'https://github.com/orgs/Cloud-Temple/projects/2'"
+  },
+  "sidebar.docSidebar.link.Status page": {
+    "message": "Status page",
+    "description": "The label for link 'Status page' in sidebar 'docSidebar', linking to 'https://status.cloud-temple.com/'"
+  },
+  "sidebar.docSidebar.doc.API Documentation": {
+    "message": "API Documentation",
+    "description": "The label for the doc item 'API Documentation' in sidebar 'docSidebar', linking to the doc console/api"
+  },
+  "sidebar.docSidebar.doc.Documentation Changelog": {
+    "message": "Documentation Changelog",
+    "description": "The label for the doc item 'Documentation Changelog' in sidebar 'docSidebar', linking to the doc changelog"
+  },
+  "sidebar.docSidebar.doc.Product Updates": {
+    "message": "Product Updates",
+    "description": "The label for the doc item 'Product Updates' in sidebar 'docSidebar', linking to the doc changelog_produits"
+  },
+  "sidebar.docSidebar.doc.FAQs": {
+    "message": "FAQs",
+    "description": "The label for the doc item 'FAQs' in sidebar 'docSidebar', linking to the doc faq"
+  },
+  "sidebar.docSidebar.doc.Intégrations & Frameworks": {
+    "message": "Integrationen & Frameworks",
+    "description": "The label for the doc item 'Intégrations & Frameworks' in sidebar 'docSidebar', linking to the doc llmaas/tutorials"
+  },
+  "sidebar.docSidebar.doc.Reconnaissance de documents (OCR)": {
+    "message": "Dokumentenerkennung (OCR)",
+    "description": "The label for the doc item 'Reconnaissance de documents (OCR)' in sidebar 'docSidebar', linking to the doc llmaas/ocr"
   }
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -3,84 +3,228 @@
     "message": "Next",
     "description": "The label for version current"
   },
-  "sidebar.docSidebar.category.AdditionalContent": {
+  "sidebar.docSidebar.category.Console": {
+    "message": "Console",
+    "description": "The label for category 'Console' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Contenu additionnel": {
     "message": "Additional Content",
-    "description": "Libellé pour la catégorie Contenu additionnel dans la barre latérale docSidebar"
+    "description": "The label for category 'Contenu additionnel' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Billing": {
+    "message": "Billing",
+    "description": "The label for category 'Billing' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Security & Identity": {
+    "message": "Security & Identity",
+    "description": "The label for category 'Security & Identity' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IAM": {
     "message": "IAM",
-    "description": "The label for category IAM in sidebar docSidebar"
+    "description": "The label for category 'IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Tutoriels IAM": {
+    "message": "IAM Tutorials",
+    "description": "The label for category 'Tutoriels IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Sécurité": {
+    "message": "Security",
+    "description": "The label for category 'Sécurité' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.AI": {
+    "message": "AI",
+    "description": "The label for category 'AI' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.llmaas_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Bare Metal": {
     "message": "Bare Metal",
-    "description": "The label for category Bare Metal in sidebar docSidebar"
+    "description": "The label for category 'Bare Metal' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Bastion": {
-    "message": "Bastion",
-    "description": "The label for category Bastion in sidebar docSidebar"
+  "sidebar.docSidebar.category.Compute": {
+    "message": "Compute",
+    "description": "The label for category 'Compute' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Housing": {
-    "message": "Housing",
-    "description": "The label for category Housing in sidebar docSidebar"
+  "sidebar.docSidebar.category.VM Instances": {
+    "message": "VM Instances",
+    "description": "The label for category 'VM Instances' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vm_instances_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IaaS OpenSource": {
     "message": "IaaS OpenSource",
-    "description": "The label for category IaaS OpenSource in sidebar docSidebar"
+    "description": "The label for category 'IaaS OpenSource' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.IaaS VMware": {
-    "message": "IaaS VMware",
-    "description": "The label for category IaaS VMware in sidebar docSidebar"
-  },
-  "sidebar.docSidebar.category.Tutorials": {
+  "sidebar.docSidebar.category.iaas_opensource_tutorials": {
     "message": "Tutorials",
-    "description": "The label for category Tutorials in sidebar docSidebar"
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.High Availability": {
     "message": "High Availability",
-    "description": "The label for category High Availability in sidebar docSidebar"
+    "description": "The label for category 'High Availability' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Backup": {
+  "sidebar.docSidebar.category.iaas_opensource_backup": {
     "message": "Backup",
-    "description": "The label for category Backup in sidebar docSidebar"
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.PaaS OpenShift": {
-    "message": "PaaS OpenShift",
-    "description": "The label for category PaaS OpenShift in sidebar docSidebar"
+  "sidebar.docSidebar.category.IaaS VMware": {
+    "message": "IaaS VMware",
+    "description": "The label for category 'IaaS VMware' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Security": {
-    "message": "Security",
-    "description": "The label for category Security in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_vmware_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.iaas_vmware_backup": {
+    "message": "Backup",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Network": {
     "message": "Network",
-    "description": "The label for category Network in sidebar docSidebar"
+    "description": "The label for category 'Network' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Privates Network": {
-    "message": "Privates Network",
-    "description": "The label for category Privates Network in sidebar docSidebar"
+  "sidebar.docSidebar.category.VPC": {
+    "message": "VPC",
+    "description": "The label for category 'VPC' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vpc_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Private Network": {
+    "message": "Private Network",
+    "description": "The label for category 'Private Network' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Internet": {
     "message": "Internet",
-    "description": "The label for category Internet in sidebar docSidebar"
+    "description": "The label for category 'Internet' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone": {
+    "message": "Private Backbone",
+    "description": "The label for category 'Private Backbone' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Storage": {
     "message": "Storage",
-    "description": "The label for category Storage in sidebar docSidebar"
+    "description": "The label for category 'Storage' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Object Storage": {
     "message": "Object Storage",
-    "description": "The label for category Object Storage in sidebar docSidebar"
+    "description": "The label for category 'Object Storage' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Contractual documents": {
-    "message": "Contractual documents",
-    "description": "The label for category Contractual documents in sidebar docSidebar"
+  "sidebar.docSidebar.category.oss_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.RACI": {
-    "message": "RACI",
-    "description": "The label for the doc item RACI in sidebar docSidebar, linking to the doc governance/paas/raci"
+  "sidebar.docSidebar.category.Monitoring": {
+    "message": "Monitoring",
+    "description": "The label for category 'Monitoring' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.Service Agreement": {
-    "message": "Service Agreement",
-    "description": "The label for the doc item Service Agreement in sidebar docSidebar, linking to the doc governance/paas/service_agreement_paas"
+  "sidebar.docSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category 'Security' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Bastion": {
+    "message": "Bastion",
+    "description": "The label for category 'Bastion' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Housing (Colocation)": {
+    "message": "Housing (Colocation)",
+    "description": "The label for category 'Housing (Colocation)' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Marketplace": {
+    "message": "Marketplace",
+    "description": "The label for category 'Marketplace' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.marketplace_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.containers_products": {
+    "message": "Containers",
+    "description": "The label for category 'Containers' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PaaS OpenShift": {
+    "message": "PaaS OpenShift",
+    "description": "The label for category 'PaaS OpenShift' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.paas_openshift_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Developer Tools": {
+    "message": "Developer Tools",
+    "description": "The label for category 'Developer Tools' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Terraform Provider": {
+    "message": "Terraform Provider",
+    "description": "The label for category 'Terraform Provider' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Kubernetes": {
+    "message": "Kubernetes",
+    "description": "The label for category 'Kubernetes' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.managed_kubernetes_tutorials": {
+    "message": "Tutorials",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Databases": {
+    "message": "Databases",
+    "description": "The label for category 'Databases' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.MariaDB Managé": {
+    "message": "Managed MariaDB",
+    "description": "The label for category 'MariaDB Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PostgreSQL Managé": {
+    "message": "Managed PostgreSQL",
+    "description": "The label for category 'PostgreSQL Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.link.Tarifs publics": {
+    "message": "Public Pricing",
+    "description": "The label for link 'Tarifs publics' in sidebar 'docSidebar', linking to 'https://www.cloud-temple.com/nos-tarifs-publics/'"
+  },
+  "sidebar.docSidebar.link.GitHub Cloud Temple": {
+    "message": "GitHub Cloud Temple",
+    "description": "The label for link 'GitHub Cloud Temple' in sidebar 'docSidebar', linking to 'https://github.com/cloud-temple'"
+  },
+  "sidebar.docSidebar.link.Roadmap produit": {
+    "message": "Product Roadmap",
+    "description": "The label for link 'Roadmap produit' in sidebar 'docSidebar', linking to 'https://github.com/orgs/Cloud-Temple/projects/2'"
+  },
+  "sidebar.docSidebar.link.Status page": {
+    "message": "Status page",
+    "description": "The label for link 'Status page' in sidebar 'docSidebar', linking to 'https://status.cloud-temple.com/'"
+  },
+  "sidebar.docSidebar.doc.API Documentation": {
+    "message": "API Documentation",
+    "description": "The label for the doc item 'API Documentation' in sidebar 'docSidebar', linking to the doc console/api"
+  },
+  "sidebar.docSidebar.doc.Documentation Changelog": {
+    "message": "Documentation Changelog",
+    "description": "The label for the doc item 'Documentation Changelog' in sidebar 'docSidebar', linking to the doc changelog"
+  },
+  "sidebar.docSidebar.doc.Product Updates": {
+    "message": "Product Updates",
+    "description": "The label for the doc item 'Product Updates' in sidebar 'docSidebar', linking to the doc changelog_produits"
+  },
+  "sidebar.docSidebar.doc.FAQs": {
+    "message": "FAQs",
+    "description": "The label for the doc item 'FAQs' in sidebar 'docSidebar', linking to the doc faq"
+  },
+  "sidebar.docSidebar.doc.Intégrations & Frameworks": {
+    "message": "Integrations & Frameworks",
+    "description": "The label for the doc item 'Intégrations & Frameworks' in sidebar 'docSidebar', linking to the doc llmaas/tutorials"
+  },
+  "sidebar.docSidebar.doc.Reconnaissance de documents (OCR)": {
+    "message": "Document Recognition (OCR)",
+    "description": "The label for the doc item 'Reconnaissance de documents (OCR)' in sidebar 'docSidebar', linking to the doc llmaas/ocr"
   }
 }

--- a/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -3,84 +3,228 @@
     "message": "Siguiente",
     "description": "The label for version current"
   },
-  "sidebar.docSidebar.category.AdditionalContent": {
+  "sidebar.docSidebar.category.Console": {
+    "message": "Console",
+    "description": "The label for category 'Console' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Contenu additionnel": {
     "message": "Contenido adicional",
-    "description": "Libellé pour la catégorie Contenu additionnel dans la barre latérale docSidebar"
+    "description": "The label for category 'Contenu additionnel' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Billing": {
+    "message": "Billing",
+    "description": "The label for category 'Billing' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Security & Identity": {
+    "message": "Security & Identity",
+    "description": "The label for category 'Security & Identity' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IAM": {
     "message": "IAM",
-    "description": "The label for category IAM in sidebar docSidebar"
+    "description": "The label for category 'IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Tutoriels IAM": {
+    "message": "Tutoriales de IAM",
+    "description": "The label for category 'Tutoriels IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Sécurité": {
+    "message": "Seguridad",
+    "description": "The label for category 'Sécurité' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.AI": {
+    "message": "AI",
+    "description": "The label for category 'AI' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.llmaas_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Bare Metal": {
     "message": "Bare Metal",
-    "description": "The label for category Bare Metal in sidebar docSidebar"
+    "description": "The label for category 'Bare Metal' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Bastion": {
-    "message": "Bastión",
-    "description": "The label for category Bastion in sidebar docSidebar"
+  "sidebar.docSidebar.category.Compute": {
+    "message": "Compute",
+    "description": "The label for category 'Compute' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Housing": {
-    "message": "Alojamiento",
-    "description": "The label for category Housing in sidebar docSidebar"
+  "sidebar.docSidebar.category.VM Instances": {
+    "message": "VM Instances",
+    "description": "The label for category 'VM Instances' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vm_instances_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IaaS OpenSource": {
     "message": "IaaS OpenSource",
-    "description": "The label for category IaaS OpenSource in sidebar docSidebar"
+    "description": "The label for category 'IaaS OpenSource' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.IaaS VMware": {
-    "message": "IaaS VMware",
-    "description": "The label for category IaaS VMware in sidebar docSidebar"
-  },
-  "sidebar.docSidebar.category.Tutorials": {
+  "sidebar.docSidebar.category.iaas_opensource_tutorials": {
     "message": "Tutoriales",
-    "description": "The label for category Tutorials in sidebar docSidebar"
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.High Availability": {
     "message": "Alta Disponibilidad",
-    "description": "The label for category High Availability in sidebar docSidebar"
+    "description": "The label for category 'High Availability' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Backup": {
-    "message": "Respaldo",
-    "description": "The label for category Backup in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_opensource_backup": {
+    "message": "Copia de seguridad",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.PaaS OpenShift": {
-    "message": "PaaS OpenShift",
-    "description": "The label for category PaaS OpenShift in sidebar docSidebar"
+  "sidebar.docSidebar.category.IaaS VMware": {
+    "message": "IaaS VMware",
+    "description": "The label for category 'IaaS VMware' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Security": {
-    "message": "Seguridad",
-    "description": "The label for category Security in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_vmware_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.iaas_vmware_backup": {
+    "message": "Copia de seguridad",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Network": {
     "message": "Red",
-    "description": "The label for category Network in sidebar docSidebar"
+    "description": "The label for category 'Network' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Privates Network": {
+  "sidebar.docSidebar.category.VPC": {
+    "message": "VPC",
+    "description": "The label for category 'VPC' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vpc_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Private Network": {
     "message": "Redes privadas",
-    "description": "The label for category Privates Network in sidebar docSidebar"
+    "description": "The label for category 'Private Network' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Internet": {
     "message": "Internet",
-    "description": "The label for category Internet in sidebar docSidebar"
+    "description": "The label for category 'Internet' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone": {
+    "message": "Private Backbone",
+    "description": "The label for category 'Private Backbone' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Storage": {
     "message": "Almacenamiento",
-    "description": "The label for category Storage in sidebar docSidebar"
+    "description": "The label for category 'Storage' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Object Storage": {
     "message": "Almacenamiento de objetos",
-    "description": "The label for category Object Storage in sidebar docSidebar"
+    "description": "The label for category 'Object Storage' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Contractual documents": {
-    "message": "Documentos contractuales",
-    "description": "The label for category Contractual documents in sidebar docSidebar"
+  "sidebar.docSidebar.category.oss_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.RACI": {
-    "message": "RACI",
-    "description": "The label for the doc item RACI in sidebar docSidebar, linking to the doc governance/paas/raci"
+  "sidebar.docSidebar.category.Monitoring": {
+    "message": "Monitoring",
+    "description": "The label for category 'Monitoring' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.Service Agreement": {
-    "message": "Acuerdo de servicio",
-    "description": "The label for the doc item Service Agreement in sidebar docSidebar, linking to the doc governance/paas/service_agreement_paas"
+  "sidebar.docSidebar.category.Security": {
+    "message": "Seguridad",
+    "description": "The label for category 'Security' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Bastion": {
+    "message": "Bastión",
+    "description": "The label for category 'Bastion' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Housing (Colocation)": {
+    "message": "Housing (Colocation)",
+    "description": "The label for category 'Housing (Colocation)' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Marketplace": {
+    "message": "Marketplace",
+    "description": "The label for category 'Marketplace' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.marketplace_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.containers_products": {
+    "message": "Containers",
+    "description": "The label for category 'Containers' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PaaS OpenShift": {
+    "message": "PaaS OpenShift",
+    "description": "The label for category 'PaaS OpenShift' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.paas_openshift_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Developer Tools": {
+    "message": "Developer Tools",
+    "description": "The label for category 'Developer Tools' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Terraform Provider": {
+    "message": "Terraform Provider",
+    "description": "The label for category 'Terraform Provider' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Kubernetes": {
+    "message": "Kubernetes",
+    "description": "The label for category 'Kubernetes' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.managed_kubernetes_tutorials": {
+    "message": "Tutoriales",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Databases": {
+    "message": "Databases",
+    "description": "The label for category 'Databases' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.MariaDB Managé": {
+    "message": "MariaDB Gestionado",
+    "description": "The label for category 'MariaDB Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PostgreSQL Managé": {
+    "message": "PostgreSQL Gestionado",
+    "description": "The label for category 'PostgreSQL Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.link.Tarifs publics": {
+    "message": "Tarifas públicas",
+    "description": "The label for link 'Tarifs publics' in sidebar 'docSidebar', linking to 'https://www.cloud-temple.com/nos-tarifs-publics/'"
+  },
+  "sidebar.docSidebar.link.GitHub Cloud Temple": {
+    "message": "GitHub Cloud Temple",
+    "description": "The label for link 'GitHub Cloud Temple' in sidebar 'docSidebar', linking to 'https://github.com/cloud-temple'"
+  },
+  "sidebar.docSidebar.link.Roadmap produit": {
+    "message": "Hoja de ruta del producto",
+    "description": "The label for link 'Roadmap produit' in sidebar 'docSidebar', linking to 'https://github.com/orgs/Cloud-Temple/projects/2'"
+  },
+  "sidebar.docSidebar.link.Status page": {
+    "message": "Status page",
+    "description": "The label for link 'Status page' in sidebar 'docSidebar', linking to 'https://status.cloud-temple.com/'"
+  },
+  "sidebar.docSidebar.doc.API Documentation": {
+    "message": "API Documentation",
+    "description": "The label for the doc item 'API Documentation' in sidebar 'docSidebar', linking to the doc console/api"
+  },
+  "sidebar.docSidebar.doc.Documentation Changelog": {
+    "message": "Documentation Changelog",
+    "description": "The label for the doc item 'Documentation Changelog' in sidebar 'docSidebar', linking to the doc changelog"
+  },
+  "sidebar.docSidebar.doc.Product Updates": {
+    "message": "Product Updates",
+    "description": "The label for the doc item 'Product Updates' in sidebar 'docSidebar', linking to the doc changelog_produits"
+  },
+  "sidebar.docSidebar.doc.FAQs": {
+    "message": "FAQs",
+    "description": "The label for the doc item 'FAQs' in sidebar 'docSidebar', linking to the doc faq"
+  },
+  "sidebar.docSidebar.doc.Intégrations & Frameworks": {
+    "message": "Integraciones y frameworks",
+    "description": "The label for the doc item 'Intégrations & Frameworks' in sidebar 'docSidebar', linking to the doc llmaas/tutorials"
+  },
+  "sidebar.docSidebar.doc.Reconnaissance de documents (OCR)": {
+    "message": "Reconocimiento de documentos (OCR)",
+    "description": "The label for the doc item 'Reconnaissance de documents (OCR)' in sidebar 'docSidebar', linking to the doc llmaas/ocr"
   }
 }

--- a/i18n/it/docusaurus-plugin-content-docs/current.json
+++ b/i18n/it/docusaurus-plugin-content-docs/current.json
@@ -3,88 +3,228 @@
     "message": "Successivo",
     "description": "The label for version current"
   },
-  "sidebar.docSidebar.category.AdditionalContent": {
+  "sidebar.docSidebar.category.Console": {
+    "message": "Console",
+    "description": "The label for category 'Console' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Contenu additionnel": {
     "message": "Contenuto aggiuntivo",
-    "description": "Libellé pour la catégorie Contenu additionnel dans la barre latérale docSidebar"
+    "description": "The label for category 'Contenu additionnel' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Billing": {
+    "message": "Billing",
+    "description": "The label for category 'Billing' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Security & Identity": {
+    "message": "Security & Identity",
+    "description": "The label for category 'Security & Identity' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IAM": {
     "message": "IAM",
-    "description": "The label for category IAM in sidebar docSidebar"
+    "description": "The label for category 'IAM' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Tutoriels": {
-    "message": "Esercitazioni",
-    "description": "The label for category Tutoriels in sidebar docSidebar"
+  "sidebar.docSidebar.category.Tutoriels IAM": {
+    "message": "Tutorial IAM",
+    "description": "The label for category 'Tutoriels IAM' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Sécurité": {
+    "message": "Sicurezza",
+    "description": "The label for category 'Sécurité' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.AI": {
+    "message": "AI",
+    "description": "The label for category 'AI' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.llmaas_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Bare Metal": {
     "message": "Bare Metal",
-    "description": "The label for category Bare Metal in sidebar docSidebar"
+    "description": "The label for category 'Bare Metal' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Bastion": {
-    "message": "Bastione",
-    "description": "The label for category Bastion in sidebar docSidebar"
+  "sidebar.docSidebar.category.Compute": {
+    "message": "Compute",
+    "description": "The label for category 'Compute' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Housing": {
-    "message": "Alloggio",
-    "description": "The label for category Housing in sidebar docSidebar"
+  "sidebar.docSidebar.category.VM Instances": {
+    "message": "VM Instances",
+    "description": "The label for category 'VM Instances' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vm_instances_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.IaaS OpenSource": {
     "message": "IaaS OpenSource",
-    "description": "The label for category IaaS OpenSource in sidebar docSidebar"
+    "description": "The label for category 'IaaS OpenSource' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.IaaS VMware": {
-    "message": "IaaS VMware",
-    "description": "The label for category IaaS VMware in sidebar docSidebar"
-  },
-  "sidebar.docSidebar.category.Tutorials": {
-    "message": "Esercitazioni",
-    "description": "The label for category Tutorials in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_opensource_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.High Availability": {
     "message": "Alta Disponibilità",
-    "description": "The label for category High Availability in sidebar docSidebar"
+    "description": "The label for category 'High Availability' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Backup": {
+  "sidebar.docSidebar.category.iaas_opensource_backup": {
     "message": "Backup",
-    "description": "The label for category Backup in sidebar docSidebar"
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.PaaS OpenShift": {
-    "message": "PaaS OpenShift",
-    "description": "The label for category PaaS OpenShift in sidebar docSidebar"
+  "sidebar.docSidebar.category.IaaS VMware": {
+    "message": "IaaS VMware",
+    "description": "The label for category 'IaaS VMware' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Security": {
-    "message": "Sicurezza",
-    "description": "The label for category Security in sidebar docSidebar"
+  "sidebar.docSidebar.category.iaas_vmware_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.iaas_vmware_backup": {
+    "message": "Backup",
+    "description": "The label for category 'Backup' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Network": {
     "message": "Rete",
-    "description": "The label for category Network in sidebar docSidebar"
+    "description": "The label for category 'Network' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Privates Network": {
+  "sidebar.docSidebar.category.VPC": {
+    "message": "VPC",
+    "description": "The label for category 'VPC' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.vpc_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Private Network": {
     "message": "Reti private",
-    "description": "The label for category Privates Network in sidebar docSidebar"
+    "description": "The label for category 'Private Network' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Internet": {
     "message": "Internet",
-    "description": "The label for category Internet in sidebar docSidebar"
+    "description": "The label for category 'Internet' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone": {
+    "message": "Private Backbone",
+    "description": "The label for category 'Private Backbone' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.private_backbone_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Storage": {
     "message": "Archiviazione",
-    "description": "The label for category Storage in sidebar docSidebar"
+    "description": "The label for category 'Storage' in sidebar 'docSidebar'"
   },
   "sidebar.docSidebar.category.Object Storage": {
     "message": "Archiviazione oggetti",
-    "description": "The label for category Object Storage in sidebar docSidebar"
+    "description": "The label for category 'Object Storage' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.category.Contractual documents": {
-    "message": "Documenti contrattuali",
-    "description": "The label for category Contractual documents in sidebar docSidebar"
+  "sidebar.docSidebar.category.oss_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.RACI": {
-    "message": "RACI",
-    "description": "The label for the doc item RACI in sidebar docSidebar, linking to the doc governance/paas/raci"
+  "sidebar.docSidebar.category.Monitoring": {
+    "message": "Monitoring",
+    "description": "The label for category 'Monitoring' in sidebar 'docSidebar'"
   },
-  "sidebar.docSidebar.doc.Service Agreement": {
-    "message": "Accordo di servizio",
-    "description": "The label for the doc item Service Agreement in sidebar docSidebar, linking to the doc governance/paas/service_agreement_paas"
+  "sidebar.docSidebar.category.Security": {
+    "message": "Sicurezza",
+    "description": "The label for category 'Security' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Bastion": {
+    "message": "Bastione",
+    "description": "The label for category 'Bastion' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Housing (Colocation)": {
+    "message": "Housing (Colocation)",
+    "description": "The label for category 'Housing (Colocation)' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Marketplace": {
+    "message": "Marketplace",
+    "description": "The label for category 'Marketplace' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.marketplace_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.containers_products": {
+    "message": "Containers",
+    "description": "The label for category 'Containers' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PaaS OpenShift": {
+    "message": "PaaS OpenShift",
+    "description": "The label for category 'PaaS OpenShift' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.paas_openshift_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Developer Tools": {
+    "message": "Developer Tools",
+    "description": "The label for category 'Developer Tools' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Terraform Provider": {
+    "message": "Terraform Provider",
+    "description": "The label for category 'Terraform Provider' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Kubernetes": {
+    "message": "Kubernetes",
+    "description": "The label for category 'Kubernetes' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.managed_kubernetes_tutorials": {
+    "message": "Tutorial",
+    "description": "The label for category 'Tutoriels' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.Databases": {
+    "message": "Databases",
+    "description": "The label for category 'Databases' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.MariaDB Managé": {
+    "message": "MariaDB Gestito",
+    "description": "The label for category 'MariaDB Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.category.PostgreSQL Managé": {
+    "message": "PostgreSQL Gestito",
+    "description": "The label for category 'PostgreSQL Managé' in sidebar 'docSidebar'"
+  },
+  "sidebar.docSidebar.link.Tarifs publics": {
+    "message": "Tariffe pubbliche",
+    "description": "The label for link 'Tarifs publics' in sidebar 'docSidebar', linking to 'https://www.cloud-temple.com/nos-tarifs-publics/'"
+  },
+  "sidebar.docSidebar.link.GitHub Cloud Temple": {
+    "message": "GitHub Cloud Temple",
+    "description": "The label for link 'GitHub Cloud Temple' in sidebar 'docSidebar', linking to 'https://github.com/cloud-temple'"
+  },
+  "sidebar.docSidebar.link.Roadmap produit": {
+    "message": "Roadmap di prodotto",
+    "description": "The label for link 'Roadmap produit' in sidebar 'docSidebar', linking to 'https://github.com/orgs/Cloud-Temple/projects/2'"
+  },
+  "sidebar.docSidebar.link.Status page": {
+    "message": "Status page",
+    "description": "The label for link 'Status page' in sidebar 'docSidebar', linking to 'https://status.cloud-temple.com/'"
+  },
+  "sidebar.docSidebar.doc.API Documentation": {
+    "message": "API Documentation",
+    "description": "The label for the doc item 'API Documentation' in sidebar 'docSidebar', linking to the doc console/api"
+  },
+  "sidebar.docSidebar.doc.Documentation Changelog": {
+    "message": "Documentation Changelog",
+    "description": "The label for the doc item 'Documentation Changelog' in sidebar 'docSidebar', linking to the doc changelog"
+  },
+  "sidebar.docSidebar.doc.Product Updates": {
+    "message": "Product Updates",
+    "description": "The label for the doc item 'Product Updates' in sidebar 'docSidebar', linking to the doc changelog_produits"
+  },
+  "sidebar.docSidebar.doc.FAQs": {
+    "message": "FAQs",
+    "description": "The label for the doc item 'FAQs' in sidebar 'docSidebar', linking to the doc faq"
+  },
+  "sidebar.docSidebar.doc.Intégrations & Frameworks": {
+    "message": "Integrazioni e framework",
+    "description": "The label for the doc item 'Intégrations & Frameworks' in sidebar 'docSidebar', linking to the doc llmaas/tutorials"
+  },
+  "sidebar.docSidebar.doc.Reconnaissance de documents (OCR)": {
+    "message": "Riconoscimento di documenti (OCR)",
+    "description": "The label for the doc item 'Reconnaissance de documents (OCR)' in sidebar 'docSidebar', linking to the doc llmaas/ocr"
   }
 }


### PR DESCRIPTION
Closes #338

## Changement

Les 4 `i18n/{en,de,es,it}/docusaurus-plugin-content-docs/current.json` sont reconstruits sur le jeu de
clés **régénéré par Docusaurus** (`yarn write-translations`), et non à la main.

| | par locale |
|---|---|
| Clés au total | **57** (contre 21 avant) |
| Traduites (recyclées ou nouvelles) | 23 |
| Traductions existantes préservées | 13 |
| Laissées identiques (libellé déjà anglais/neutre, y compris en FR) | 21 |
| Clés orphelines supprimées | 8 (9 pour `it`) |

## Ce qui manquait vraiment

Pas les traductions — les **clés**. Des traductions humaines existaient déjà, mais accrochées à des clés
que Docusaurus n'émet plus (`category.AdditionalContent`, `category.Tutorials`, `category.Backup`,
`category.Privates Network`…). `write-translations` ne purgeant pas les clés mortes, l'anomalie était
invisible. Elles sont **recyclées vers les bonnes clés** plutôt que réécrites.

Mécanisme utile à connaître : une catégorie **avec** `key:` dans `sidebars.ts` est traduite via cette clé
(`category.llmaas_tutorials`), **sans** `key:` via son libellé (`category.Sécurité`). C'est ce qui
désambiguïse les 10 catégories toutes libellées « Tutoriels ».

## Deux recyclages refusés — à challenger

- **`Housing`** était traduit `Unterkunft` / `Alojamiento` / `Alloggio`, c'est-à-dire **hébergement de
  personnes**. Faux sens pour du housing datacenter : `Housing (Colocation)` est conservé à l'identique
  dans les 4 langues.
- **La valeur EN de `Privates Network`** était `"Privates Network"`, un germanisme. Corrigée en
  `Private Network` ; les de/es/it étaient justes et sont recyclés.

## Quatre valeurs arbitrées par le contenu, pas par la clé orpheline

| Libellé | Orpheline | Contenu traduit du dépôt | Retenu |
|---|---|---|---|
| Tutoriels (de) | `Anleitungen` | `Tutorials` — 14 pages sur 15 | **Tutorials** |
| Tutoriels (it) | `Esercitazioni` | `Tutorial` — 11 sur 14 | **Tutorial** |
| Backup (de) | `Backup` | `Sicherung` — titre « Häufig gestellte Fragen zur Sicherung » | **Sicherung** |
| Backup (es) | `Respaldo` | `Copia de seguridad` | **Copia de seguridad** |

Sans cet arbitrage, le menu allemand affichait une catégorie « Anleitungen » juste à côté de pages
« Tutorials ». Les noms de produits reprennent mot pour mot ceux de `databases_overview.md` de chaque
locale (`Managed MariaDB`, `Verwaltete MariaDB`, `MariaDB Gestionado`, `MariaDB Gestito`), pour que le
menu et le contenu concordent.

## Vérification

`yarn build` **exit 0**, aucune nouvelle page en warning SSG. Puis extraction des libellés du bloc
`theme-doc-sidebar-menu` du HTML généré, sur **toutes** les pages de chaque locale :

| locale | pages balayées | libellés de menu distincts | libellés français restants |
|---|---|---|---|
| fr | 243 | 112 | 10 — *attendu, locale source* |
| en | 242 | 112 | **aucun** |
| de | 244 | 116 | **aucun** |
| es | 243 | 117 | **aucun** |
| it | 244 | 116 | **aucun** |

Le menu français est inchangé.

> Note : une première passe de vérification via `grep` sur `menu__link` renvoyait 0 partout — un faux
> négatif, le HTML minifié imbriquant le libellé dans un `<span title="…">` interne. Les chiffres
> ci-dessus viennent de l'extraction corrigée.

## Hors périmètre — signalé dans #338

1. `navbar.json` est **absent** pour en/de/es/it (présent seulement en `fr`) ; `footer.json` et
   `code.json` ont aussi des clés manquantes → navbar et footer partiellement non traduits.
2. `i18n/es/…/network/internet/tutorials.md` porte `title: Tutoriels` (français). Invisible dans les
   menus — la page n'est pas référencée dans `sidebars.ts` — mais visible sur la page elle-même.
   3 pages `es` et 3 `it` sont titrées « Tutorials » en anglais ; certains titres sont à moitié traduits.
3. `Databases`, `Compute`, `Billing`, `Monitoring`, `Containers`, `Security & Identity`, `Status page`,
   `Developer Tools`, `API Documentation`, `Documentation Changelog`, `Product Updates`, `FAQs` restent
   en anglais en de/es/it, alors que `Security`, `Storage`, `Network` y sont localisés. Incohérence réelle,
   mais la lever demande une décision éditoriale sur ~12 libellés — volontairement écartée d'un correctif
   mécanique.

⚠️ Le job CI `build-branch` échouera : le tag Docker `docs:${BRANCH_NAME}` est invalide dès que la branche
contient un `/`. Bug pré-existant du workflow (voir #337), indépendant de cette PR — `Build Documentation`
passe.
