### PR TITLE
docs(managed_kubernetes): corrige le développement du sigle MCP dans usingopencost

### DIFF
--- a/docs/managed_kubernetes/tutorials/usingopencost.md
+++ b/docs/managed_kubernetes/tutorials/usingopencost.md
@@ -55,7 +55,7 @@ Un dashboard Grafana est également disponible pour visualiser les données d'Op
 
 ## Utilisation Avancée : Intégration avec une IA (Serveur MCP)
 
-Pour les utilisateurs avancés, OpenCost peut être directement interrogé depuis l'assistant conversationnel Cline (ou autre) grâce au système de **MCP (Multi-purpose Co-processor) servers**. Cela vous permet de scripter des requêtes et d'obtenir des données de coût directement dans vos conversations.
+Pour les utilisateurs avancés, OpenCost peut être directement interrogé depuis l'assistant conversationnel Cline (ou autre) grâce au système de **MCP (Model Context Protocol) servers**. Cela vous permet de scripter des requêtes et d'obtenir des données de coût directement dans vos conversations.
 
 ### 1. Configuration du MCP OpenCost dans Cline
 
@@ -104,7 +104,7 @@ Une fois ce fichier sauvegardé, Cline chargera automatiquement le MCP `opencost
 >Pour interagir avec le MCP en langage naturel, l'IA sous-jacente doit avoir accès à des modèles de langage (LLMs), soit localement (LMStudio, etc), soit via une connexion à des services publics comme GPT-5 ou Gemini, soit en utilisant notre produit **[LLM-as-a-Service](pathname:///llmaas/llmaas)** souveraine.
 
 
-Après configuration, vous pouvez utiliser les outils LLM pour effectuer des requetes en langage natuel sur ce serveur MCP.
+Après configuration, vous pouvez utiliser les outils LLM pour effectuer des requêtes en langage naturel sur ce serveur MCP.
 
 #### Exemple
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
@@ -55,7 +55,7 @@ Ein Grafana-Dashboard ist ebenfalls verfügbar, um die OpenCost-Daten zu visuali
 
 ## Erweiterte Nutzung: Integration mit einer KI (MCP-Server)
 
-Für fortgeschrittene Benutzer kann OpenCost direkt über den Konversationsassistenten Cline (oder andere) abgefragt werden, dank des Systems der **MCP (Multi-purpose Co-processor) servers**. Dies ermöglicht es Ihnen, Abfragen zu skripten und Kostendaten direkt in Ihren Konversationen abzurufen.
+Für fortgeschrittene Benutzer kann OpenCost direkt über den Konversationsassistenten Cline (oder andere) abgefragt werden, dank des Systems der **MCP (Model Context Protocol) servers**. Dies ermöglicht es Ihnen, Abfragen zu skripten und Kostendaten direkt in Ihren Konversationen abzurufen.
 
 ### 1. Konfiguration von MCP OpenCost in Cline
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
@@ -55,7 +55,7 @@ A Grafana dashboard is also available to visualize OpenCost data. This dashboard
 
 ## Advanced Usage: Integration with an AI (MCP Server)
 
-For advanced users, OpenCost can be directly queried from the Cline conversational assistant (or others) using the **MCP (Multi-purpose Co-processor) servers** system. This allows you to script queries and retrieve cost data directly within your conversations.
+For advanced users, OpenCost can be directly queried from the Cline conversational assistant (or others) using the **MCP (Model Context Protocol) servers** system. This allows you to script queries and retrieve cost data directly within your conversations.
 
 ### 1. Configuring OpenCost MCP in Cline
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
@@ -55,7 +55,7 @@ Un dashboard de Grafana también está disponible para visualizar los datos de O
 
 ## Uso Avanzado: Integración con una IA (Servidor MCP)
 
-Para usuarios avanzados, OpenCost puede consultarse directamente desde el asistente conversacional Cline (u otro) gracias al sistema de **servidores MCP (Multi-purpose Co-processor)**. Esto le permite automatizar consultas y obtener datos de costos directamente en sus conversaciones.
+Para usuarios avanzados, OpenCost puede consultarse directamente desde el asistente conversacional Cline (u otro) gracias al sistema de **servidores MCP (Model Context Protocol)**. Esto le permite automatizar consultas y obtener datos de costos directamente en sus conversaciones.
 
 ### 1. Configuración del MCP OpenCost en Cline
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/managed_kubernetes/tutorials/usingopencost.md
@@ -55,7 +55,7 @@ Un dashboard Grafana è inoltre disponibile per visualizzare i dati di OpenCost.
 
 ## Utilizzo Avanzato: Integrazione con un'IA (Serveur MCP)
 
-Per gli utenti avanzati, OpenCost può essere interrogato direttamente dall'assistente conversazionale Cline (ou autre) grazie al sistema di **MCP (Multi-purpose Co-processor) servers**. Ciò vi consente di automatizzare le query e ottenere i dati sui costi direttamente nelle vostre conversazioni.
+Per gli utenti avanzati, OpenCost può essere interrogato direttamente dall'assistente conversazionale Cline (ou autre) grazie al sistema di **MCP (Model Context Protocol) servers**. Ciò vi consente di automatizzare le query e ottenere i dati sui costi direttamente nelle vostre conversazioni.
 
 ### 1. Configurazione del MCP OpenCost in Cline
 


### PR DESCRIPTION
Closes #340 — **correction bloquante, à merger avant demain.**

## Changement

Tutoriel « Suivre les coûts avec OpenCost », section « Utilisation Avancée : Intégration avec une IA (Serveur MCP) ».

**1. Sigle MCP, les 5 langues (ligne 58)** — `Multi-purpose Co-processor` → `Model Context Protocol`.

| Locale | Après |
|---|---|
| fr | `grâce au système de **MCP (Model Context Protocol) servers**` |
| en | `using the **MCP (Model Context Protocol) servers** system` |
| de | `dank des Systems der **MCP (Model Context Protocol) servers**` |
| es | `gracias al sistema de **servidores MCP (Model Context Protocol)**` |
| it | `grazie al sistema di **MCP (Model Context Protocol) servers**` |

L'ordre des mots propre à l'espagnol (`servidores MCP (…)`) est préservé.

**2. Deux fautes, FR uniquement (ligne 107)** — `effectuer des requetes en langage natuel` → `effectuer des requêtes en langage naturel`. Les 4 traductions de cette phrase étaient déjà correctes, elles ne sont pas touchées.

## Vérification

- `yarn build` **exit 0**, aucune nouvelle page en warning SSG.
- Balayage de `docs/` + `i18n/` : **0** occurrence de `Multi-purpose` restante, et `MCP (Model Context Protocol)` apparaît exactement **5 fois**, une par langue. Aucun autre développement du sigle ailleurs dans la doc.
- Contrôlé sur les **5 pages HTML générées** (`usingopencost.html` de chaque locale) : `Multi-purpose` = 0, `Model Context Protocol` = 1, et la phrase FR corrigée est bien présente.
- Diff strictement limité au texte : 6 lignes remplacées sur 5 fichiers, aucun changement de structure.

## Relevé au passage — non corrigé

La version **italienne** de la ligne 58 contient un reste de français : `dall'assistente conversazionale Cline **(ou autre)**` au lieu de `(o altro)`. C'est sur la ligne même que je modifie, mais hors du périmètre que tu as fixé — je ne l'ai pas touché pour ne pas élargir une correction bloquante. Un mot et je l'ajoute à cette PR.

⚠️ Le job CI `build-branch` échouera : tag Docker invalide dès que la branche contient un `/` (bug pré-existant, #337). `Build Documentation` passe.