### PR TITLE
fix(ci): corrige le tag Docker des branches et monte les actions encore en Node.js 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,11 @@ jobs:
       id-token: write
     environment: dev # Ensure this matches your GitHub environment name
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -37,13 +37,13 @@ jobs:
         run: yarn build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   # Job for feature branches (building and pushing an unversioned Docker image)
   build-branch:
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -68,20 +68,20 @@ jobs:
         run: yarn build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Branch Name
         id: extract_branch
         run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/production/Dockerfile.prebuilt
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -112,16 +112,16 @@ jobs:
         run: yarn build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/production/Dockerfile.prebuilt
@@ -135,9 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -156,16 +156,16 @@ jobs:
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/production/Dockerfile.prebuilt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,17 @@ jobs:
 
       - name: Extract Branch Name
         id: extract_branch
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          # Un tag Docker n'accepte que [A-Za-z0-9._-], ne peut pas commencer par '.' ou '-'
+          # et fait 128 caracteres au maximum. La convention de branches du depot
+          # (docs/..., fix/..., tech/...) contient des '/' : sans cette normalisation,
+          # buildx echoue avec "invalid reference format".
+          DOCKER_TAG="$(printf '%s' "$BRANCH_NAME" \
+            | sed -e 's/[^A-Za-z0-9._-]/-/g' -e 's/^[.-]/_/' \
+            | cut -c1-128)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
 
       - name: Log in to DockerHub
         uses: docker/login-action@v4
@@ -87,7 +97,7 @@ jobs:
           file: ./docker/production/Dockerfile.prebuilt
           push: true
           platforms: linux/amd64,linux/arm64/v8
-          tags: cloudtempleinfra/docs:${{ env.BRANCH_NAME }}
+          tags: cloudtempleinfra/docs:${{ env.DOCKER_TAG }}
 
   # Job for the main branch (building and pushing an unversioned Docker image)
   build-main:


### PR DESCRIPTION
Closes #337
Closes #342

Corrige les **deux** anomalies du run [#978](https://github.com/Cloud-Temple/docs/actions/runs/32371255766) : l'erreur qui faisait échouer la CI de chaque branche de feature, et le warning de dépréciation Node.js 20.

## 1. L'erreur — tag Docker invalide (#342)

```
buildx failed with: ERROR: failed to build: invalid tag
"***/docs:fix/mcp-model-context-protocol-340": invalid reference format
```

`${GITHUB_REF#refs/heads/}` retire le préfixe mais **conserve les `/`**, alors qu'un tag Docker n'accepte que `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`. Toute branche respectant la convention du dépôt (`docs/…`, `fix/…`, `tech/…`) produisait donc un tag invalide.

`build-tag` n'était pas affecté : il utilise `${GITHUB_REF##*/}`, qui ne garde que le dernier segment. C'est cette asymétrie entre les deux jobs qui faisait que seul `build-branch` cassait.

Le nom est désormais normalisé avant usage : hors `[A-Za-z0-9._-]` → `-`, `.` ou `-` initial → `_`, troncature à 128.

### Testé, pas supposé

La logique shell a été extraite du workflow et rejouée **en `bash`** (comme le runner), chaque sortie validée contre la regex de tag Docker :

| Cas | Entrée → sortie | Verdict |
|---|---|---|
| branche réelle | `fix/mcp-model-context-protocol-340` → `fix-mcp-model-context-protocol-340` | valide |
| branche réelle | `docs/remove-beta-badge-databases-334` → `docs-remove-beta-badge-databases-334` | valide |
| sans `/` | `303-ajout-de-la-doc-tech-sovereign-soc` → inchangé | valide |
| plusieurs `/` | `feat/a/b/c/deep` → `feat-a-b-c-deep` | valide |
| `-` initial | `-leading-dash` → `_leading-dash` | valide |
| `.` initial | `.hidden` → `_hidden` | valide |
| accents + espaces | `feat/accents-éàç-et espaces` → `feat-accents--------et-espaces` | valide |
| caractères interdits | `feat/weird~^:*?chars` → `feat-weird-----chars` | valide |
| 200 caractères | tronqué à exactement **128** | valide |

12 cas au total, tous valides.

## 2. Le warning — actions encore en Node.js 20 (#337)

GitHub force déjà ces actions sur node24 et émet un warning de dépréciation ([changelog GitHub](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

| Action | Avant | Après | 1ʳᵉ majeure en node24 |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | v5 |
| `actions/setup-node` | v4 | **v7** | v5 |
| `docker/setup-buildx-action` | v2 | **v4** | v4 |
| `docker/login-action` | v2 | **v4** | v4 |
| `docker/build-push-action` | v4 | **v7** | v7 |
| `actions/deploy-pages` | v4 | **v5** | v5 |
| `actions/upload-pages-artifact` | v3 | **v5** | *composite* — montée par cohérence |

`deploy-pages` ne figurait pas dans l'annotation : son job ne tourne que sur `dev`, donc il n'avait pas encore émis le warning. Il l'aurait fait au prochain merge.

### Breaking changes vérifiés, aucun impact ici

- **`checkout` v5 → v7** : node24 puis ESM ; v7 durcit le checkout des PR de fork pour `pull_request_target` et `workflow_run` — déclencheurs **non utilisés** par ce workflow (`push` / `create`).
- **`setup-node` v5** : active un cache automatique si `package.json` déclare `packageManager` — **absent** de ce dépôt ; v6 limite ce cache auto à npm. Dans les deux cas le `cache: yarn` explicite reste prioritaire.
- **actions `docker/*`** : node24 par défaut, runner ≥ `v2.327.1` requis — les runners `ubuntu-latest` sont très au-delà.

**`node-version: 22` est inchangé** dans les 4 jobs : le warning portait sur le runtime des actions, pas sur le Node qui build la documentation.

## Vérification

- YAML reparsé : 4 jobs intacts (`deploy-dev`, `build-branch`, `build-main`, `build-tag`).
- Le run de cette branche est le premier à valider les deux correctifs de bout en bout, **push DockerHub inclus** — c'est lui qui prouve que le tag normalisé passe.

## Hors périmètre — écarté délibérément

Pinner Node via un `.nvmrc` : `node-version: 22` reste recopié dans les 4 jobs et `engines` reste à `">=18.0"`. À traiter séparément si souhaité.
